### PR TITLE
Recursive Include Support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,5 @@ recursive-include ramlfications *.py *.ini *.json
 recursive-include docs *.py *.rst
 recursive-include docs/_static *
 prune docs/_build
-recursive-include tests *.py *.json *.md *.py *.raml *.yaml *.xsd *.ini *.xml
+recursive-include tests *.py *.json *.md *.py *.raml *.yaml *.xsd *.ini *.xml *.txt
 

--- a/ramlfications/loader.py
+++ b/ramlfications/loader.py
@@ -35,11 +35,7 @@ class RAMLLoader(object):
                 return inputfile.read()
 
         with open(file_name) as inputfile:
-            try:
-                return yaml.load(inputfile)
-            except yaml.loader.ConstructorError:
-                msg = "Recursively-including files not supported."
-                raise LoadRAMLError(msg)
+            return yaml.load(inputfile, self._ordered_loader)
 
     def _ordered_load(self, stream, loader=yaml.Loader):
         """
@@ -54,6 +50,9 @@ class RAMLLoader(object):
         OrderedLoader.add_constructor("!include", self._yaml_include)
         OrderedLoader.add_constructor(
             yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, construct_mapping)
+
+        self._ordered_loader = OrderedLoader
+
         return yaml.load(stream, OrderedLoader)
 
     def load(self, raml):

--- a/tests/data/examples/includes/all-the-properties.raml
+++ b/tests/data/examples/includes/all-the-properties.raml
@@ -1,0 +1,5 @@
+#%RAML 0.8
+
+external: !include properties.raml
+foo: !include foo-properties.raml
+not_yaml: !include not_yaml.txt

--- a/tests/data/examples/includes/not_yaml.txt
+++ b/tests/data/examples/includes/not_yaml.txt
@@ -1,0 +1,1 @@
+This is just a string.

--- a/tests/data/examples/nested-includes.raml
+++ b/tests/data/examples/nested-includes.raml
@@ -1,0 +1,4 @@
+#%RAML 0.8
+title: GitHub API Demo - Includes
+version: v3
+include_one: !include includes/all-the-properties.raml

--- a/tests/data/examples/nonyaml-includes.raml
+++ b/tests/data/examples/nonyaml-includes.raml
@@ -1,0 +1,4 @@
+#%RAML 0.8
+title: GitHub API Demo - Includes
+version: v3
+not_yaml: !include includes/not_yaml.txt

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -42,6 +42,44 @@ def test_load_file():
         assert dict_equal(raml, expected_data)
 
 
+def test_load_file_with_nested_includes():
+    raml_file = os.path.join(EXAMPLES + "nested-includes.raml")
+    with open(raml_file) as f:
+        raml = loader.RAMLLoader().load(f)
+
+        expected_data = {
+            'include_one': {
+                'external': {
+                    'propertyA': 'valueA',
+                    'propertyB': 'valueB'
+                },
+                'foo': {
+                    'foo': 'FooBar',
+                    'bar': 'BarBaz'
+                },
+                'not_yaml': "This is just a string.\n",
+            },
+            'title': 'GitHub API Demo - Includes',
+            'version': 'v3'
+        }
+
+        assert dict_equal(raml, expected_data)
+
+
+def test_load_file_with_nonyaml_include():
+    raml_file = os.path.join(EXAMPLES + "nonyaml-includes.raml")
+    with open(raml_file) as f:
+        raml = loader.RAMLLoader().load(f)
+
+        expected_data = {
+            'not_yaml': "This is just a string.\n",
+            'title': 'GitHub API Demo - Includes',
+            'version': 'v3'
+        }
+
+        assert dict_equal(raml, expected_data)
+
+
 def test_load_string():
     raml_str = ("""
                 - foo
@@ -59,14 +97,6 @@ def test_yaml_parser_error():
     with pytest.raises(LoadRAMLError) as e:
         loader.RAMLLoader().load(open(raml_obj))
     msg = "Error parsing RAML:"
-    assert msg in e.value.args[0]
-
-
-def test_cyclic_includes_raises_error():
-    raml_file = os.path.join(EXAMPLES + "cyclic_includes.raml")
-    with pytest.raises(LoadRAMLError) as e:
-        loader.RAMLLoader().load(open(raml_file))
-    msg = "Recursively-including files not supported."
     assert msg in e.value.args[0]
 
 


### PR DESCRIPTION
Right now, the support for `!include` only works at the first level and     only supports including yaml (and json) files.

This change should make it so that if you have a raml file with an include that pulls in a file that also has an include, it'll keep walking that tree.

Also, it looks at the file extension and if it isn't `yaml`, `raml` or `json`, it assumes you just want to pull it in as a string, rather than make any attempt to parse it.