### PR TITLE
Add Nose to Dev Dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,3 +9,4 @@ pytest==2.6.4
 pytest-cov==1.8.1
 mock==1.0.1
 pytest-mock==0.4.3
+nose==1.3.6


### PR DESCRIPTION
When I tried getting the tests running locally, I saw lots of explosions about there being no module called 'nose', so I've added it to the development dependencies.