### PR TITLE
Collecting All Validation Errors on .validate() Instead of Raising Exception

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -101,13 +101,17 @@ To validate a RAML file with Python:
 .. code-block:: python
 
    >>> from ramlfications import validate
-   >>> RAML_FILE = "/path/to/invalid/no-title.raml"
+   >>> RAML_FILE = "/path/to/invalid/no-base-uri-no-title.raml"
    >>> validate(RAML_FILE)
-   InvalidRootNodeError: RAML File does not define an API title.
+   InvalidRAMLError:
+       InvalidRootNodeError: RAML File does not define the baseUri.
+       InvalidRootNodeError: RAML File does not define an API title.
 
 .. note::
-    When using ``validate`` within Python (versus the command line utility), if the RAML \
-    file is valid, then nothing is returned.  Only invalid files will return an exception.
+    When using ``validate`` within Python (versus the command line utility), \
+    if the RAML file is valid, then nothing is returned; only invalid files \
+    will return an exception.  You can access the individual errors \
+    via the ``errors`` attribute on the exception.
 
 If you have additionally supported items beyond the standard (e.g. protocols beyond HTTP/S), you
 can still validate your code by passing in your config file.

--- a/ramlfications/__init__.py
+++ b/ramlfications/__init__.py
@@ -89,6 +89,8 @@ def validate(raml, config_file=None):
         according to RAML `specification <http://raml.org/spec.html>`_.
     :raises InvalidParameterError: Named parameter is invalid \
         according to RAML `specification <http://raml.org/spec.html>`_.
+    :raises InvalidRAMLError: RAML file is invalid according to RAML \
+        `specification <http://raml.org/spec.html>`_.
     """
     loader = load(raml)
     config = setup_config(config_file)

--- a/ramlfications/__main__.py
+++ b/ramlfications/__main__.py
@@ -32,7 +32,7 @@ def validate(ramlfile, config):
                     fg="green")
 
     except InvalidRAMLError as e:
-        msg = "Error validating file {0}: {1}".format(ramlfile, e)
+        msg = "Error validating file {0}: \n{1}".format(ramlfile, e)
         click.secho(msg, fg="red", err=True)
         raise SystemExit(1)
 

--- a/ramlfications/_decorators.py
+++ b/ramlfications/_decorators.py
@@ -1,0 +1,11 @@
+from .errors import BaseRAMLError
+
+
+def collecterrors(func):
+    def func_wrapper(inst, attr, value):
+        try:
+            func(inst, attr, value)
+        except BaseRAMLError as e:
+            inst.errors.append(e)
+
+    return func_wrapper

--- a/ramlfications/errors.py
+++ b/ramlfications/errors.py
@@ -10,24 +10,38 @@ from __future__ import absolute_import, division, print_function
 
 
 class InvalidRAMLError(Exception):
+    def __init__(self, errors):
+        super(InvalidRAMLError, self).__init__(
+            "Validation errors were found.")
+        self.errors = errors
+
+    def __str__(self):
+        output = "\n"
+        for e in self.errors:
+            output += "\t{0}: {1}\n".format(e.__class__.__name__, e)
+        # Strip last newline
+        return output[:-1]
+
+
+class BaseRAMLError(Exception):
     pass
 
 
-class InvalidRootNodeError(InvalidRAMLError):
+class InvalidRootNodeError(BaseRAMLError):
     pass
 
 
-class InvalidResourceNodeError(InvalidRAMLError):
+class InvalidResourceNodeError(BaseRAMLError):
     pass
 
 
-class InvalidParameterError(InvalidRAMLError):
+class InvalidParameterError(BaseRAMLError):
     def __init__(self, message, parameter):
         super(InvalidParameterError, self).__init__(message)
         self.parameter = parameter
 
 
-class InvalidSecuritySchemeError(InvalidRAMLError):
+class InvalidSecuritySchemeError(BaseRAMLError):
     pass
 
 

--- a/ramlfications/parameters.py
+++ b/ramlfications/parameters.py
@@ -87,6 +87,7 @@ class BaseParameter(object):
     default      = attr.ib(repr=False)
     config       = attr.ib(repr=False,
                            validator=attr.validators.instance_of(dict))
+    errors       = attr.ib(repr=False)
     repeat       = attr.ib(repr=False, default=False)
     pattern      = attr.ib(repr=False, default=None,
                            validator=string_type_parameter)
@@ -209,6 +210,7 @@ class Header(object):
     maximum      = attr.ib(repr=False, validator=integer_number_type_parameter)
     config       = attr.ib(repr=False,
                            validator=attr.validators.instance_of(dict))
+    errors       = attr.ib(repr=False)
     type         = attr.ib(repr=False, default="string", validator=header_type)
     enum         = attr.ib(repr=False, default=None,
                            validator=string_type_parameter)
@@ -252,6 +254,7 @@ class Body(object):
     form_params = attr.ib(repr=False, validator=body_form)
     config      = attr.ib(repr=False,
                           validator=attr.validators.instance_of(dict))
+    errors      = attr.ib(repr=False)
 
 
 @attr.s
@@ -274,6 +277,7 @@ class Response(object):
     body     = attr.ib(repr=False)
     config   = attr.ib(repr=False,
                        validator=attr.validators.instance_of(dict))
+    errors   = attr.ib(repr=False)
     method   = attr.ib(default=None)
 
     @property
@@ -305,6 +309,7 @@ class SecurityScheme(object):
     desc          = attr.ib(repr=False)
     settings      = attr.ib(repr=False, validator=defined_sec_scheme_settings)
     config        = attr.ib(repr=False)
+    errors        = attr.ib(repr=False)
 
     @property
     def description(self):

--- a/ramlfications/raml.py
+++ b/ramlfications/raml.py
@@ -64,6 +64,7 @@ class RootNode(object):
     raml_obj         = attr.ib(repr=False)
     config           = attr.ib(repr=False,
                                validator=attr.validators.instance_of(dict))
+    errors           = attr.ib(repr=False)
 
 
 @attr.s
@@ -102,6 +103,7 @@ class BaseNode(object):
     media_type      = attr.ib(repr=False)
     desc            = attr.ib(repr=False)
     protocols       = attr.ib(repr=False)
+    errors          = attr.ib(repr=False)
 
     @property
     def description(self):

--- a/ramlfications/validate.py
+++ b/ramlfications/validate.py
@@ -7,6 +7,8 @@ import re
 
 from six import iterkeys
 
+from ._decorators import collecterrors
+
 from .errors import *  # NOQA
 
 
@@ -14,18 +16,17 @@ from .errors import *  # NOQA
 # RAMLRoot validators
 #####
 
+@collecterrors
 def root_version(inst, attr, value):
     """Require an API Version (e.g. api.foo.com/v1)."""
     base_uri = inst.raml_obj.get("baseUri")
-    if not value and"{version}" in base_uri:
+    if base_uri and "{version}" in base_uri and not value:
         msg = ("RAML File's baseUri includes {version} parameter but no "
                "version is defined.")
         raise InvalidRootNodeError(msg)
-    elif not value:
-        msg = "RAML File does not define an API version."
-        raise InvalidRootNodeError(msg)
 
 
+@collecterrors
 def root_base_uri(inst, attr, value):
     """Require a Base URI."""
     if not value:
@@ -33,6 +34,7 @@ def root_base_uri(inst, attr, value):
         raise InvalidRootNodeError(msg)
 
 
+@collecterrors
 def root_base_uri_params(inst, attr, value):
     """
     Require that Base URI parameters have a ``default`` parameter set.
@@ -49,6 +51,7 @@ def root_base_uri_params(inst, attr, value):
                 raise InvalidRootNodeError(msg)
 
 
+@collecterrors
 def root_uri_params(inst, attr, value):
     """
     Assert that where is no ``version`` parameter in the regular URI parameters
@@ -60,6 +63,7 @@ def root_uri_params(inst, attr, value):
                 raise InvalidRootNodeError(msg)
 
 
+@collecterrors
 def root_protocols(inst, attr, value):
     """
     Only support HTTP/S plus what is defined in user-config
@@ -72,6 +76,7 @@ def root_protocols(inst, attr, value):
                 raise InvalidRootNodeError(msg)
 
 
+@collecterrors
 def root_title(inst, attr, value):
     """
     Require a title for the defined API.
@@ -81,6 +86,7 @@ def root_title(inst, attr, value):
         raise InvalidRootNodeError(msg)
 
 
+@collecterrors
 def root_docs(inst, attr, value):
     """
     Assert that if there is ``documentation`` defined in the root of the
@@ -97,10 +103,12 @@ def root_docs(inst, attr, value):
 
 
 # TODO: finish
+@collecterrors
 def root_schemas(inst, attr, value):
     pass
 
 
+@collecterrors
 def root_media_type(inst, attr, value):
     """
     Only support media types based on config and regex
@@ -112,12 +120,14 @@ def root_media_type(inst, attr, value):
             raise InvalidRootNodeError(msg)
 
 
+@collecterrors
 def root_resources(inst, attr, value):
     if not value:
         msg = "API does not define any resources."
         raise InvalidRootNodeError(msg)
 
 
+@collecterrors
 def root_secured_by(inst, attr, value):
     pass
 
@@ -125,6 +135,7 @@ def root_secured_by(inst, attr, value):
 #####
 # Security Scheme Validators
 #####
+@collecterrors
 def defined_sec_scheme_settings(inst, attr, value):
     """Assert that ``settings`` are defined/not an empty map."""
     if not value:
@@ -136,6 +147,7 @@ def defined_sec_scheme_settings(inst, attr, value):
 #####
 # ResourceType validators
 #####
+@collecterrors
 def defined_resource_type(inst, attr, value):
     """
     Assert that a resource type is defined (e.g. not an empty map) or is
@@ -151,6 +163,7 @@ def defined_resource_type(inst, attr, value):
 #####
 # Trait validators
 #####
+@collecterrors
 def defined_trait(inst, attr, value):
     """Assert that a trait is defined (e.g. not an empty map)."""
     if not value:
@@ -161,6 +174,7 @@ def defined_trait(inst, attr, value):
 #####
 # Shared Validators for Resource & Resource Type Node
 #####
+@collecterrors
 def assigned_traits(inst, attr, value):
     """
     Assert assigned traits are defined in the RAML Root and correctly
@@ -202,6 +216,7 @@ def assigned_traits(inst, attr, value):
                     raise InvalidResourceNodeError(msg)
 
 
+@collecterrors
 def assigned_res_type(inst, attr, value):
     """
     Assert only one (or none) assigned resource type is defined in the RAML
@@ -232,6 +247,7 @@ def assigned_res_type(inst, attr, value):
 #####
 # Parameter Validators
 #####
+@collecterrors
 def header_type(inst, attr, value):
     """Supported header type"""
     if value and value not in inst.config.get("prim_types"):
@@ -239,6 +255,7 @@ def header_type(inst, attr, value):
         raise InvalidParameterError(msg, "header")
 
 
+@collecterrors
 def body_mime_type(inst, attr, value):
     """Supported MIME media type for request/response"""
     if value:
@@ -248,6 +265,7 @@ def body_mime_type(inst, attr, value):
             raise InvalidParameterError(msg, "body")
 
 
+@collecterrors
 def body_schema(inst, attr, value):
     """
     Assert no ``schema`` is defined if body as a form-related MIME media type
@@ -258,6 +276,7 @@ def body_schema(inst, attr, value):
         raise InvalidParameterError(msg, "body")
 
 
+@collecterrors
 def body_example(inst, attr, value):
     """
     Assert no ``example`` is defined if body as a form-related MIME media type
@@ -268,6 +287,7 @@ def body_example(inst, attr, value):
         raise InvalidParameterError(msg, "body")
 
 
+@collecterrors
 def body_form(inst, attr, value):
     """
     Assert ``formParameters`` are defined if body has a form-related
@@ -280,6 +300,7 @@ def body_form(inst, attr, value):
         raise InvalidParameterError(msg, "body")
 
 
+@collecterrors
 def response_code(inst, attr, value):
     """
     Assert a valid response code.
@@ -296,6 +317,7 @@ def response_code(inst, attr, value):
 #####
 # Primative Validators
 #####
+@collecterrors
 def integer_number_type_parameter(inst, attr, value):
     """
     Assert correct parameter attributes for ``integer`` or ``number``
@@ -310,6 +332,7 @@ def integer_number_type_parameter(inst, attr, value):
             raise InvalidParameterError(msg, "BaseParameter")
 
 
+@collecterrors
 def string_type_parameter(inst, attr, value):
     """
     Assert correct parameter attributes for ``string`` primative parameter

--- a/tests/data/validate/no-base-uri-no-title.raml
+++ b/tests/data/validate/no-base-uri-no-title.raml
@@ -1,0 +1,6 @@
+#%RAML 0.8
+version: 1
+/foo:
+  description: FooBar
+  get:
+    description: Get some FooBar

--- a/tests/data/validate/optional-base-uri-params.raml
+++ b/tests/data/validate/optional-base-uri-params.raml
@@ -24,11 +24,7 @@ uriParameters:
       example: "foo-api"
   get:
     description: "Get some foo"
-    type: "string"
-    example: "foobar"
   /bar:
     displayName: bar
     get:
       description: "Get some bar"
-      type: "string"
-      example: "barfoo"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -37,12 +37,18 @@ def test_validate_fail(runner):
     """
     Raise error for invalid RAML file via CLI when validating.
     """
-    raml_file = os.path.join(VALIDATE, "no-title.raml")
+    raml_file = os.path.join(VALIDATE, "no-base-uri-no-title.raml")
     exp_code = 1
-    exp_msg = "Error validating file {0}: {1}\n".format(
-        raml_file, 'RAML File does not define an API title.')
+    exp_msg_1 = "Error validating file {0}: \n".format(raml_file)
+    exp_msg_2 = 'RAML File does not define an API title.'
+    exp_msg_3 = 'RAML File does not define the baseUri.'
+
     result = runner.invoke(main.validate, [raml_file])
-    check_result(exp_code, exp_msg, result)
+
+    assert result.exit_code == exp_code
+    assert exp_msg_1 in result.output
+    assert exp_msg_2 in result.output
+    assert exp_msg_3 in result.output
 
 
 def test_tree(runner):
@@ -65,8 +71,9 @@ def test_tree_invalid(runner):
     raml_file = os.path.join(VALIDATE, "no-title.raml")
     config_file = os.path.join(VALIDATE, "valid-config.ini")
     exp_code = 1
-    exp_msg = '"{0}" is not a valid RAML file: {1}\n'.format(
-        raml_file, 'RAML File does not define an API title.')
+    exp_msg = '"{0}" is not a valid RAML file: \n\t{1}: {2}\n'.format(
+        raml_file, 'InvalidRootNodeError',
+        'RAML File does not define an API title.')
     result = runner.invoke(main.tree, [raml_file, "--color=light",
                            "--config={0}".format(config_file)])
     check_result(exp_code, exp_msg, result)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -14,7 +14,16 @@ from ramlfications._helpers import load_file
 from .base import VALIDATE
 
 
-raises = pytest.raises(errors.InvalidRootNodeError)
+raises = pytest.raises(errors.InvalidRAMLError)
+
+
+# Search a list of errors for a specific error
+def _error_exists(error_list, error_type, error_msg):
+    for e in error_list:
+        if isinstance(e, error_type) and e.args == error_msg:
+            return True
+
+    return False
 
 
 def load_raml(filename):
@@ -33,16 +42,14 @@ def test_invalid_root_protocols():
     with raises as e:
         parse(raml, config)
     msg = ("'FTP' not a valid protocol for a RAML-defined API.",)
-    assert e.value.args == msg
+    assert _error_exists(e.value.errors, errors.InvalidRootNodeError, msg)
 
 
-def test_invalid_version_not_defined():
+def test_undefined_version():
     raml = load_raml("no-version.raml")
     config = load_config("valid-config.ini")
-    with raises as e:
-        parse(raml, config)
-    msg = ('RAML File does not define an API version.',)
-    assert e.value.args == msg
+    parsed_raml = parse(raml, config)
+    assert not parsed_raml.errors
 
 
 def test_invalid_version_base_uri():
@@ -52,7 +59,17 @@ def test_invalid_version_base_uri():
         parse(raml, config)
     msg = ("RAML File's baseUri includes {version} parameter but no "
            "version is defined.",)
-    assert e.value.args == msg
+    assert _error_exists(e.value.errors, errors.InvalidRootNodeError, msg)
+
+
+def test_undefined_base_uri_and_title():
+    raml = load_raml("no-base-uri-no-title.raml")
+    config = load_config("valid-config.ini")
+    with raises as e:
+        parse(raml, config)
+    assert len(e.value.errors) == 2
+    assert isinstance(e.value.errors[0], errors.InvalidRootNodeError)
+    assert isinstance(e.value.errors[1], errors.InvalidRootNodeError)
 
 
 def test_invalid_base_uri_not_defined():
@@ -61,7 +78,7 @@ def test_invalid_base_uri_not_defined():
     with raises as e:
         parse(raml, config)
     msg = ("RAML File does not define the baseUri.",)
-    assert e.value.args == msg
+    assert _error_exists(e.value.errors, errors.InvalidRootNodeError, msg)
 
 
 def test_invalid_base_uri_wrong_type():
@@ -69,8 +86,10 @@ def test_invalid_base_uri_wrong_type():
     config = load_config("valid-config.ini")
     with raises as e:
         parse(raml, config)
-    msg = ("baseUriParameter 'domainName' must be a string",)
+    msg = ("Validation errors were found.",)
+    msg1 = ("baseUriParameter 'domainName' must be a string",)
     assert e.value.args == msg
+    assert _error_exists(e.value.errors, errors.InvalidRootNodeError, msg1)
 
 
 def test_invalid_base_uri_optional():
@@ -79,7 +98,7 @@ def test_invalid_base_uri_optional():
     with raises as e:
         parse(raml, config)
     msg = ("baseUriParameter 'domainName' must be required",)
-    assert e.value.args == msg
+    assert _error_exists(e.value.errors, errors.InvalidRootNodeError, msg)
 
 
 def test_invalid_uri_params_version():
@@ -88,7 +107,7 @@ def test_invalid_uri_params_version():
     with raises as e:
         parse(raml, config)
     msg = ("'version' can only be defined in baseUriParameters.",)
-    assert e.value.args == msg
+    assert _error_exists(e.value.errors, errors.InvalidRootNodeError, msg)
 
 
 def test_invalid_no_title():
@@ -96,7 +115,8 @@ def test_invalid_no_title():
     config = load_config("valid-config.ini")
     with raises as e:
         parse(raml, config)
-    assert ('RAML File does not define an API title.',) == e.value.args
+    msg = ('RAML File does not define an API title.',)
+    assert _error_exists(e.value.errors, errors.InvalidRootNodeError, msg)
 
 
 def test_invalid_docs_not_list():
@@ -112,7 +132,8 @@ def test_invalid_docs_no_title():
     config = load_config("valid-config.ini")
     with raises as e:
         parse(raml, config)
-    assert ("API Documentation requires a title.",) == e.value.args
+    msg = ("API Documentation requires a title.",)
+    assert _error_exists(e.value.errors, errors.InvalidRootNodeError, msg)
 
 
 def test_invalid_docs_no_content():
@@ -120,33 +141,36 @@ def test_invalid_docs_no_content():
     config = load_config("valid-config.ini")
     with raises as e:
         parse(raml, config)
-    assert ("API Documentation requires content defined.",) == e.value.args
+    msg = ("API Documentation requires content defined.",)
+    assert _error_exists(e.value.errors, errors.InvalidRootNodeError, msg)
 
 
 def test_assigned_undefined_resource_type():
     raml = load_raml("undefined-resource-type-str.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidResourceNodeError) as e:
+    with raises as e:
         parse(raml, config)
     msg = ("Resource Type 'undefined' is assigned to '/foo' but is not "
            "defined in the root of the API.",)
-    assert msg == e.value.args
+    assert _error_exists(e.value.errors, errors.InvalidResourceNodeError, msg)
 
 
 def test_no_resources_defined():
     raml = load_raml("no-resources.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidRootNodeError) as e:
+    with raises as e:
         parse(raml, config)
-    assert ("API does not define any resources.",) == e.value.args
+    msg = ("API does not define any resources.",)
+    assert _error_exists(e.value.errors, errors.InvalidRootNodeError, msg)
 
 
 def test_invalid_media_type():
     raml = load_raml("invalid-media-type.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidRootNodeError) as e:
+    with raises as e:
         parse(raml, config)
-    assert ("Unsupported MIME Media Type: 'awesome/sauce'.",) == e.value.args
+    msg = ("Unsupported MIME Media Type: 'awesome/sauce'.",)
+    assert _error_exists(e.value.errors, errors.InvalidRootNodeError, msg)
 
 
 # TODO: move assert from parser to validate
@@ -162,21 +186,21 @@ def test_invalid_trait_obj():
 def test_traits_undefined():
     raml = load_raml("trait-undefined.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidResourceNodeError) as e:
+    with raises as e:
         parse(raml, config)
     msg = ("Trait 'undefined' is assigned to '/users/{user_id}/playlists' "
            "but is not defined in the root of the API.",)
-    assert msg == e.value.args
+    assert _error_exists(e.value.errors, errors.InvalidResourceNodeError, msg)
 
 
 def test_no_traits_defined():
     raml = load_raml("no-traits-defined.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidResourceNodeError) as e:
+    with raises as e:
         parse(raml, config)
     msg = ("Trying to assign traits that are not defined"
            "in the root of the API.",)
-    assert msg == e.value.args
+    assert _error_exists(e.value.errors, errors.InvalidResourceNodeError, msg)
 
 
 # TODO: move assert from parser to validate
@@ -192,90 +216,100 @@ def test_unsupported_trait_type_str():
 def test_unsupported_trait_type_array_ints():
     raml = load_raml("trait-unsupported-type-array-ints.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidResourceNodeError) as e:
+    with raises as e:
         parse(raml, config)
     msg = ("'12' needs to be a string referring to a trait, or a dictionary "
            "mapping parameter values to a trait",)
-    assert msg == e.value.args
+    assert _error_exists(e.value.errors, errors.InvalidResourceNodeError, msg)
 
 
 def test_too_many_assigned_resource_types():
     raml = load_raml("too-many-assigned-res-types.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidResourceNodeError) as e:
+    with raises as e:
         parse(raml, config)
     msg = ("Too many resource types applied to '/foobar'.",)
-    assert msg == e.value.args
+    assert _error_exists(e.value.errors, errors.InvalidResourceNodeError, msg)
 
 
 #####
 # Parameter Validators
 #####
-
 def test_invalid_request_header_param():
     raml = load_raml("invalid-parameter-type-header.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidParameterError) as e:
+    with raises as e:
         parse(raml, config)
     msg = ("'invalidType' is not a valid primative parameter type",)
-    assert msg == e.value.args
+    assert _error_exists(e.value.errors, errors.InvalidParameterError, msg)
 
 
 def test_invalid_body_mime_type():
     raml = load_raml("invalid-body-mime-type.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidParameterError) as e:
+    with raises as e:
         parse(raml, config)
     msg = ("Unsupported MIME Media Type: 'invalid/mediatype'.",)
-    assert msg == e.value.args
+    assert _error_exists(e.value.errors, errors.InvalidParameterError, msg)
 
 
 def test_invalid_body_schema():
     raml = load_raml("invalid-body-form-schema.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidParameterError) as e:
+    with raises as e:
         parse(raml, config)
-    msg = ("Body must define formParameters, not schema/example.",)
+    msg = ("Validation errors were found.",)
+    msg1 = ("Body must define formParameters, not schema/example.",)
+    msg2 = ("Body with mime_type 'application/x-www-form-urlencoded' "
+            "requires formParameters.",)
     assert msg == e.value.args
+    assert _error_exists(e.value.errors, errors.InvalidParameterError, msg1)
+    assert _error_exists(e.value.errors, errors.InvalidParameterError, msg2)
 
 
 def test_invalid_body_example():
     raml = load_raml("invalid-body-form-example.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidParameterError) as e:
+    with raises as e:
         parse(raml, config)
-    msg = ("Body must define formParameters, not schema/example.",)
+
+    msg = ("Validation errors were found.",)
+    msg1 = ("Body must define formParameters, not schema/example.",)
+    msg2 = ("Body with mime_type 'application/x-www-form-urlencoded' "
+            "requires formParameters.",)
     assert msg == e.value.args
+    assert _error_exists(e.value.errors, errors.InvalidParameterError, msg1)
+    assert _error_exists(e.value.errors, errors.InvalidParameterError, msg2)
 
 
 def test_invalid_body_no_form_params():
     raml = load_raml("invalid-body-no-form-params.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidParameterError) as e:
+    with raises as e:
         parse(raml, config)
     msg = ("Body with mime_type 'application/x-www-form-urlencoded' requires "
            "formParameters.",)
-    assert msg == e.value.args
+    assert _error_exists(e.value.errors, errors.InvalidParameterError, msg)
 
 
 def test_invalid_response_code_str():
     raml = load_raml("invalid-response-code-str.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidParameterError) as e:
+    with raises as e:
         parse(raml, config)
     msg = (
         "Response code 'foo' must be an integer representing an HTTP code.",
     )
-    assert msg == e.value.args
+    assert _error_exists(e.value.errors, errors.InvalidParameterError, msg)
 
 
 def test_invalid_response_code():
     raml = load_raml("invalid-response-code.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidParameterError) as e:
+    with raises as e:
         parse(raml, config)
     msg = ("'299' not a valid HTTP response code.",)
-    assert msg == e.value.args
+    assert _error_exists(e.value.errors, errors.InvalidParameterError, msg)
 
 
 #####
@@ -285,21 +319,21 @@ def test_invalid_response_code():
 def test_invalid_integer_number_type():
     raml = load_raml("invalid-integer-number-type.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidParameterError) as e:
+    with raises as e:
         parse(raml, config)
     msg = ("invalidParamType must be either a number or integer to have "
            "minimum attribute set, not 'string'.",)
-    assert msg == e.value.args
+    assert _error_exists(e.value.errors, errors.InvalidParameterError, msg)
 
 
 def test_invalid_string_type():
     raml = load_raml("invalid-string-type.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidParameterError) as e:
+    with raises as e:
         parse(raml, config)
     msg = ("invalidParamType must be a string type to have min_length "
            "attribute set, not 'integer'.",)
-    assert msg == e.value.args
+    assert _error_exists(e.value.errors, errors.InvalidParameterError, msg)
 
 
 #####
@@ -309,30 +343,30 @@ def test_invalid_string_type():
 def test_empty_mapping_res_type():
     raml = load_raml("empty-mapping-resource-type.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidResourceNodeError) as e:
+    with raises as e:
         parse(raml, config)
 
     msg = ("The resourceType 'emptyType' requires definition.",)
-    assert e.value.args == msg
+    assert _error_exists(e.value.errors, errors.InvalidResourceNodeError, msg)
 
 
 def test_empty_mapping_trait():
     raml = load_raml("empty-mapping-trait.raml")
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidResourceNodeError) as e:
+    with raises as e:
         parse(raml, config)
 
     msg = ("The trait 'emptyTrait' requires definition.",)
-    assert e.value.args == msg
+    assert _error_exists(e.value.errors, errors.InvalidResourceNodeError, msg)
 
 
 def test_empty_mapping_sec_scheme_settings():
     _raml = "empty-mapping-security-scheme-settings.raml"
     raml = load_raml(_raml)
     config = load_config("valid-config.ini")
-    with pytest.raises(errors.InvalidSecuritySchemeError) as e:
+    with raises as e:
         parse(raml, config)
-
     msg = ("'settings' for security scheme 'EmptySettingsScheme' require "
            "definition.",)
-    assert e.value.args == msg
+    assert _error_exists(e.value.errors, errors.InvalidSecuritySchemeError,
+                         msg)


### PR DESCRIPTION
Addresses: https://github.com/spotify/ramlfications/issues/21

New usage:

    errors = ramlfications.validate(RAML_FILE)
    if errors:
        for error in errors:
            print(error)
    else:
        print("Success!")

`ramlfications.parse` also collects all errors, but raises an exception for the first validation error in the `errors` list;  this was to keep the new functionality close to how it works now.  

Implementation Notes:
- Initialized an `errors` array in `parser.py` that gets passed through the node creation -- similar to `config`.
- Created `parse_raml_passive` that sits next to `parse_raml` so that `ramlfications.parse` and `ramlfications.validate` can have the different behaviors that are described above;  `parse_raml_passive` does not raise an exception after parsing, and `parse_raml` does. 
