### PR TITLE
Gracefully catch parser.py AttributeErrors

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -7,8 +7,19 @@ To make participation as pleasant as possible, this project adheres to the `Code
 
 Here are a few hints and rules to get you started:
 
+- Current status of the project (including issues & PRs) can be seen on our `waffle.io`_ page.
+- Meaning of GitHub labels:
+    - ``help wanted``: Feeling generous with your time? These issues are up for grabs.  Ask any questions in the comments of the issue.
+    - ``in progress``: This issue is currently being worked on.
+    - ``ready``: Issue/bug has been confirmed, and is available for anyone to work on.
+    - ``feature``: Feature/idea to extend ``ramlfications``.
+    - ``bug``: A bug or issue within ``ramlfications``.
+    - ``no repro``: A filled bug that can not be reproduced (feel free to comment/reopen if you find you are seeing this bug).
+    - ``wontfix``: A filled issue deemed not relevant to the project in some way.
+    - ``duplicate``: Either duplicate issue or PR.
+
 - Take a look at the :doc:`wishlist` for inspiration.
-- Any GitHub issue that is not assigned is up for grabs.
+- Any GitHub issue that is labeled ``ready`` is up for grabs.
 - Add yourself to the AUTHORS.rst_ file in an alphabetical fashion.
   Every contribution is valuable and shall be credited.
 - If your change is noteworthy, add an entry to the changelog_.
@@ -33,3 +44,4 @@ Thank you for considering to contribute to ``ramlfications``!
 .. _`Code of Conduct`: https://www.python.org/psf/codeofconduct/
 .. _changelog: https://github.com/spotify/ramlfications/blob/master/docs/changelog.rst
 .. _AUTHORS.rst: https://github.com/spotify/ramlfications/blob/master/AUTHORS.rst
+.. _`waffle.io`: https://waffle.io/spotify/ramlfications

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,10 @@ ramlfications: RAML reference implementation in Python
     :target: https://pypi.python.org/pypi/ramlfications/
     :alt: Development Status
 
+.. image:: https://badge.waffle.io/spotify/ramlfications.png?label=ready&title=Ready
+    :target: https://waffle.io/spotify/ramlfications
+    :alt: Project Management
+
 .. begin
 
 Requirements and Installation
@@ -51,6 +55,8 @@ Developer Setup
 
 If you'd like to contribute or develop upon ``ramlfications``, be sure to read `How to Contribute`_
 first.
+
+You can see the progress of ``ramlfications`` on our `waffle.io`_ page.
 
 System requirements:
 ^^^^^^^^^^^^^^^^^^^^
@@ -126,3 +132,4 @@ Feel free to drop by ``#ramlfications`` on Freenode (`webchat`_) or ping via `Tw
 .. _`webchat`: http://webchat.freenode.net?channels=%23ramlfications&uio=ND10cnVlJjk9dHJ1ZQb4
 .. _`econchick`: https://github.com/econchick
 .. _`Twitter`: https://twitter.com/roguelynn
+.. _`waffle.io`: https://waffle.io/spotify/ramlfications

--- a/docs/wishlist.rst
+++ b/docs/wishlist.rst
@@ -1,14 +1,18 @@
 :orphan:
 
-Wishlist, TODOs, and Contribution Inspiration
-=============================================
+Wishlist
+========
 
 Ideally, this should mirror the `issues`_ listed on the ``ramlfications`` `github`_ page.  Ideally.
 
 * Features:
-    * ``[ ]`` Add ability to "pluralize" and "singularize" parameters in resourceTypes and traits
-    * ``[ ]`` Parse `$ref` in JSON schemas
-    * ``[ ]`` Construct RAML via Python objects then `dump`/`dumps` them to file/string output.
+    * Add ability to "pluralize" and "singularize" parameters in resourceTypes and traits (see `Issue 3`_).
+    * Parse ``<< parameters >>`` in Resource nodes (see `Issue 2`_).
+    * Parse ``$ref`` in JSON schemas – currently being worked on (see `PR 19`_).
+    * Construct RAML via Python objects then ``dump``/``dumps`` them to file/string output.
 
 .. _`github`: https://github.com/spotify/ramlfications
 .. _`issues`: https://github.com/spotify/ramlfications/issues
+.. _`PR 19`: https://github.com/spotify/ramlfications/pull/19
+.. _`Issue 2`: https://github.com/spotify/ramlfications/issues/2
+.. _`Issue 3`: https://github.com/spotify/ramlfications/issues/3

--- a/ramlfications/errors.py
+++ b/ramlfications/errors.py
@@ -27,6 +27,10 @@ class InvalidParameterError(InvalidRAMLError):
         self.parameter = parameter
 
 
+class InvalidSecuritySchemeError(InvalidRAMLError):
+    pass
+
+
 #####
 # Loader Exceptions
 #####

--- a/ramlfications/parameters.py
+++ b/ramlfications/parameters.py
@@ -29,17 +29,14 @@ class Content(object):
         """
         Return raw Markdown/plain text written in the RAML file
         """
-        return self.data or None
+        return self.data
 
     @property
     def html(self):
         """
         Returns parsed Markdown into HTML
         """
-        try:
-            return md.markdown(self.data)
-        except TypeError:
-            return None
+        return md.markdown(self.data)
 
     def __repr__(self):
         return self.raw
@@ -99,7 +96,9 @@ class BaseParameter(object):
 
     @property
     def description(self):
-        return Content(self.desc)
+        if self.desc:
+            return Content(self.desc)
+        return None
 
 
 @attr.s
@@ -221,7 +220,9 @@ class Header(object):
 
     @property
     def description(self):
-        return Content(self.desc)
+        if self.desc:
+            return Content(self.desc)
+        return None
 
 
 @attr.s
@@ -277,7 +278,9 @@ class Response(object):
 
     @property
     def description(self):
-        return Content(self.desc)
+        if self.desc:
+            return Content(self.desc)
+        return None
 
 
 @attr.s
@@ -300,9 +303,11 @@ class SecurityScheme(object):
     type          = attr.ib(repr=False)
     described_by  = attr.ib(repr=False)
     desc          = attr.ib(repr=False)
-    settings      = attr.ib(repr=False)
+    settings      = attr.ib(repr=False, validator=defined_sec_scheme_settings)
     config        = attr.ib(repr=False)
 
     @property
     def description(self):
-        return Content(self.desc)
+        if self.desc:
+            return Content(self.desc)
+        return None

--- a/ramlfications/raml.py
+++ b/ramlfications/raml.py
@@ -16,10 +16,6 @@ AVAILABLE_METHODS = [
 ]
 
 
-class RAMLParserError(Exception):
-    pass
-
-
 @attr.s
 class RootNode(object):
     """
@@ -95,7 +91,6 @@ class BaseNode(object):
     :param list protocols: List of ``str`` 's of supported protocols. \
         Defaults to :py:class:`RootNode`'s ``protocols``.
     """
-    raw             = attr.ib(repr=False)
     root            = attr.ib(repr=False)
     headers         = attr.ib(repr=False)
     body            = attr.ib(repr=False)
@@ -122,6 +117,7 @@ class TraitNode(BaseNode):
     :param str usage: Usage of trait
     """
     name  = attr.ib()
+    raw   = attr.ib(repr=False, validator=defined_trait)
     usage = attr.ib(repr=False)
 
 
@@ -152,6 +148,7 @@ class ResourceTypeNode(BaseNode):
 
     """
     name             = attr.ib()
+    raw              = attr.ib(repr=False, validator=defined_resource_type)
     type             = attr.ib(repr=False, validator=assigned_res_type)
     method           = attr.ib(repr=False)
     usage            = attr.ib(repr=False)
@@ -191,6 +188,7 @@ class ResourceNode(BaseNode):
         :py:class:`parameters.SecurityScheme` objects, or ``None``.
     """
     name             = attr.ib(repr=False)
+    raw              = attr.ib(repr=False)
     parent           = attr.ib(repr=False)
     method           = attr.ib()
     display_name     = attr.ib(repr=False)

--- a/ramlfications/validate.py
+++ b/ramlfications/validate.py
@@ -123,6 +123,42 @@ def root_secured_by(inst, attr, value):
 
 
 #####
+# Security Scheme Validators
+#####
+def defined_sec_scheme_settings(inst, attr, value):
+    """Assert that ``settings`` are defined/not an empty map."""
+    if not value:
+        msg = ("'settings' for security scheme '{0}' require "
+               "definition.".format(inst.name))
+        raise InvalidSecuritySchemeError(msg)
+
+
+#####
+# ResourceType validators
+#####
+def defined_resource_type(inst, attr, value):
+    """
+    Assert that a resource type is defined (e.g. not an empty map) or is
+    inherited from a defined resource type.
+    """
+    if not inst.type:
+        if not value:
+            msg = ("The resourceType '{0}' requires "
+                   "definition.".format(inst.name))
+            raise InvalidResourceNodeError(msg)
+
+
+#####
+# Trait validators
+#####
+def defined_trait(inst, attr, value):
+    """Assert that a trait is defined (e.g. not an empty map)."""
+    if not value:
+        msg = "The trait '{0}' requires definition.".format(inst.name)
+        raise InvalidResourceNodeError(msg)
+
+
+#####
 # Shared Validators for Resource & Resource Type Node
 #####
 def assigned_traits(inst, attr, value):

--- a/tests/data/examples/complete-valid-example.raml
+++ b/tests/data/examples/complete-valid-example.raml
@@ -204,6 +204,9 @@ securitySchemes:
                 description: another form parameter
       settings:
         foo: bar
+  - no_desc:
+      settings:
+        foo: bar
 traits:
   - filterable:
       usage: Some description about using filterable

--- a/tests/data/examples/empty-mapping-resource-type.raml
+++ b/tests/data/examples/empty-mapping-resource-type.raml
@@ -1,0 +1,210 @@
+#%RAML 0.8
+title: Spotify Web API
+version: v1
+baseUri: https://api.spotify.com/{version}
+mediaType: application/json
+documentation:
+  - title: Spotify Web API Docs
+    content: |
+      Welcome to the _Spotify Web API_ specification. For more information about
+      how to use the API, check out the [Spotify's developer site](https://developer.spotify.com/web-api/).
+resourceTypes:
+  - emptyType:
+securitySchemes:
+  - oauth_2_0:
+      description: |
+          Spotify supports OAuth 2.0 for authenticating all API requests.
+      type: OAuth 2.0
+      describedBy:
+        headers:
+          Authorization:
+            description: |
+              Used to send a valid OAuth 2 access token.
+            type: string
+        responses:
+          401:
+            description: |
+              Bad or expired token. This can happen if the user revoked a token or
+              the access token has expired. You should re-authenticate the user.
+          403:
+            description: |
+              Bad OAuth request (access token without necessary scope).
+      settings:
+        authorizationUri: https://accounts.spotify.com/authorize
+        accessTokenUri: https://accounts.spotify.com/api/token
+        authorizationGrants: [ code, token ]
+        scopes:
+          - "user-library-read"
+          - "user-library-modify"
+          - "user-read-private"
+          - "user-read-birthdate"
+          - "user-read-email"
+          - "user-follow-read"
+          - "user-follow-modify"
+          - "playlist-read-collaborative"
+          - "playlist-read-private"
+          - "playlist-modify-public"
+          - "playlist-modify-private"
+traits:
+  - filterable:
+      queryParameters:
+        fields:
+          description: A comma-separated list of fields to filter query
+          type: string
+          example: items(added_by.id,track(name,href,album(name,href)))
+          displayName: Fields
+  - paged:
+      queryParameters:
+        limit:
+          displayName: Limit
+          description: The maximum number of items to return
+          type: integer
+          example: 10
+          minimum: 0
+          default: 20
+          maximum: 50
+          required: false
+        offset:
+          displayName: Offset
+          description: The index of the first item to return
+          type: integer
+          example: 5
+          default: 0
+          required: false
+/me:
+  displayName: current-user
+  securedBy: [ oauth_2_0: {scopes: ["user-read-private", "user-read-birthdate", "user-read-email"]} ]
+  /tracks:
+    displayName: current-user-saved-tracks
+    type: collection
+    put:
+      description: |
+        [Save Tracks for Current User](https://developer.spotify.com/web-api/save-tracks-user/)
+      securedBy: [ oauth_2_0: {scopes: ["user-library-modify"]}]
+      queryParameters:
+        ids:
+          displayName: Spotify Track IDs
+          type: string
+          description: A comma-separated list of IDs
+          required: true
+          example: "7ouMYWpwJ422jRcDASZB7P,4VqPOruhp5EdPBeR92t6lQ,2takcwOaAZWiXQijPHIx7B"
+      responses:
+        200:
+          body:
+            text/plain:
+    delete:
+      description: |
+        [Remove Tracks for Current User](https://developer.spotify.com/web-api/remove-tracks-user/)
+      securedBy: [ oauth_2_0: {scopes: ["user-library-modify"]}]
+      queryParameters:
+        ids:
+          displayName: Spotify Track IDs
+          type: string
+          description: A comma-separated list of IDs
+          required: true
+          example: "7ouMYWpwJ422jRcDASZB7P,4VqPOruhp5EdPBeR92t6lQ,2takcwOaAZWiXQijPHIx7B"
+      responses:
+        200:
+          body:
+            text/plain:
+/users/{user_id}/playlists:
+  type: collection
+  uriParameters:
+    user_id:
+      displayName: Owner ID
+      type: string
+      description: The user's Spotify user ID.
+      example: jmperezperez
+  displayName: playlists
+  /{playlist_id}:
+    type: item
+    displayName: playlist
+    uriParameters:
+      playlist_id:
+        displayName: Playlist ID
+        description: The Spotify playlist ID.
+        example: 3cEYpjA9oz9GiPac4AsH4n
+        type: string
+        required: true
+    put:
+      description: |
+        [Change a Playlist's Details](https://developer.spotify.com/web-api/change-playlist-details/)
+      securedBy: [ oauth_2_0: { scopes: ["playlist-modify-public", "playlist-modify-private"]}]
+      responses:
+        200:
+          body:
+            text/plain:
+    /followers:
+      displayName: playlist-followers
+      put:
+        description: |
+          [Follow a Playlist](https://developer.spotify.com/web-api/follow-playlist/)
+        securedBy: [ oauth_2_0: { scopes: ["playlist-modify-public", "playlist-modify-private"]}]
+        body:
+          application/json:
+            schema: |
+              {
+                "$schema": "http://json-schema.org/draft-03/schema",
+                "type": "object",
+                "required": false,
+                "properties": {
+                  "public": {
+                    "type": "boolean",
+                    "required": false
+                  }
+                }
+              }
+        responses:
+          200:
+            body:
+              text/plain:
+      delete:
+        description: |
+          [Unfollow a Playlist](https://developer.spotify.com/web-api/unfollow-playlist/)
+        securedBy: [ oauth_2_0: { scopes: ["playlist-modify-public", "playlist-modify-private"]}]
+        responses:
+          200:
+            body:
+              text/plain:
+/me/following:
+  displayName: following
+  put:
+    description: |
+      [Follow Artists or Users](https://developer.spotify.com/web-api/follow-artists-users/)
+    securedBy: [ oauth_2_0: {scopes: ["user-follow-modify"]} ]
+    queryParameters:
+      type:
+        displayName: Item Type
+        description: The type to follow.
+        type: string
+        example: artist
+        enum: ["artist", "user"]
+        required: true
+      ids:
+        displayName: Spotify IDs
+        type: string
+        description: A comma-separated list of the artists or users ids
+        required: true
+        example: "2CIMQHirSU0MQqyYHq0eOx,57dN52uHvrHOxijzpIgu3E,1vCWHaC5f2uS3yhpwWbIA6"
+    responses:
+      204:
+  delete:
+    description: |
+      [Unfollow Artists or Users](https://developer.spotify.com/web-api/unfollow-artists-users/)
+    securedBy: [ oauth_2_0: {scopes: ["user-follow-modify"]} ]
+    queryParameters:
+      type:
+        displayName: Item Type
+        description: The type to unfollow.
+        type: string
+        example: artist
+        enum: ["artist", "user"]
+        required: true
+      ids:
+        displayName: Spotify IDs
+        type: string
+        description: A comma-separated list of the artists or users ids
+        required: true
+        example: "2CIMQHirSU0MQqyYHq0eOx,57dN52uHvrHOxijzpIgu3E,1vCWHaC5f2uS3yhpwWbIA6"
+    responses:
+      204:

--- a/tests/data/examples/empty-mapping.raml
+++ b/tests/data/examples/empty-mapping.raml
@@ -1,0 +1,232 @@
+#%RAML 0.8
+title: Spotify Web API
+version: v1
+baseUri: https://api.spotify.com/{version}
+mediaType: application/json
+documentation:
+  - title: Spotify Web API Docs
+    content: |
+      Welcome to the _Spotify Web API_ specification. For more information about
+      how to use the API, check out the [Spotify's developer site](https://developer.spotify.com/web-api/).
+resourceTypes:
+  - base:
+      get?: &common
+        headers:
+          Accept:
+            description: It is used to set specified media type.
+            type: string
+          EmptyAccept:
+          EmptyAcceptParams:
+            description:
+        responses:
+          429:
+            description: |
+              API rate limit exceeded. See http://developer.spotify.com/web-api/user-guide/#rate-limiting for details.
+          430:
+      post?: *common
+      put?: *common
+      delete?: *common
+  - item:
+      type: base
+      get?:
+  - collection:
+      type: base
+      get?:
+securitySchemes:
+  - oauth_2_0:
+      description: |
+          Spotify supports OAuth 2.0 for authenticating all API requests.
+      type: OAuth 2.0
+      describedBy:
+        headers:
+          Authorization:
+            description: |
+              Used to send a valid OAuth 2 access token.
+            type: string
+        responses:
+          401:
+            description: |
+              Bad or expired token. This can happen if the user revoked a token or
+              the access token has expired. You should re-authenticate the user.
+          403:
+            description: |
+              Bad OAuth request (access token without necessary scope).
+      settings:
+        authorizationUri: https://accounts.spotify.com/authorize
+        accessTokenUri: https://accounts.spotify.com/api/token
+        authorizationGrants: [ code, token ]
+        scopes:
+          - "user-library-read"
+          - "user-library-modify"
+          - "user-read-private"
+          - "user-read-birthdate"
+          - "user-read-email"
+          - "user-follow-read"
+          - "user-follow-modify"
+          - "playlist-read-collaborative"
+          - "playlist-read-private"
+          - "playlist-modify-public"
+          - "playlist-modify-private"
+traits:
+  - filterable:
+      queryParameters:
+        fields:
+          description: A comma-separated list of fields to filter query
+          type: string
+          example: items(added_by.id,track(name,href,album(name,href)))
+          displayName: Fields
+  - paged:
+      queryParameters:
+        limit:
+          displayName: Limit
+          description: The maximum number of items to return
+          type: integer
+          example: 10
+          minimum: 0
+          default: 20
+          maximum: 50
+          required: false
+        offset:
+          displayName: Offset
+          description: The index of the first item to return
+          type: integer
+          example: 5
+          default: 0
+          required: false
+/me:
+  displayName: current-user
+  securedBy: [ oauth_2_0: {scopes: ["user-read-private", "user-read-birthdate", "user-read-email"]} ]
+  /tracks:
+    displayName: current-user-saved-tracks
+    type: collection
+    put:
+      description: |
+        [Save Tracks for Current User](https://developer.spotify.com/web-api/save-tracks-user/)
+      securedBy: [ oauth_2_0: {scopes: ["user-library-modify"]}]
+      queryParameters:
+        ids:
+          displayName: Spotify Track IDs
+          type: string
+          description: A comma-separated list of IDs
+          required: true
+          example: "7ouMYWpwJ422jRcDASZB7P,4VqPOruhp5EdPBeR92t6lQ,2takcwOaAZWiXQijPHIx7B"
+      responses:
+        200:
+          body:
+            text/plain:
+    delete:
+      description: |
+        [Remove Tracks for Current User](https://developer.spotify.com/web-api/remove-tracks-user/)
+      securedBy: [ oauth_2_0: {scopes: ["user-library-modify"]}]
+      queryParameters:
+        ids:
+          displayName: Spotify Track IDs
+          type: string
+          description: A comma-separated list of IDs
+          required: true
+          example: "7ouMYWpwJ422jRcDASZB7P,4VqPOruhp5EdPBeR92t6lQ,2takcwOaAZWiXQijPHIx7B"
+      responses:
+        200:
+          body:
+            text/plain:
+/users/{user_id}/playlists:
+  type: collection
+  uriParameters:
+    user_id:
+      displayName: Owner ID
+      type: string
+      description: The user's Spotify user ID.
+      example: jmperezperez
+  displayName: playlists
+  /{playlist_id}:
+    type: item
+    displayName: playlist
+    uriParameters:
+      playlist_id:
+        displayName: Playlist ID
+        description: The Spotify playlist ID.
+        example: 3cEYpjA9oz9GiPac4AsH4n
+        type: string
+        required: true
+    put:
+      description: |
+        [Change a Playlist's Details](https://developer.spotify.com/web-api/change-playlist-details/)
+      securedBy: [ oauth_2_0: { scopes: ["playlist-modify-public", "playlist-modify-private"]}]
+      responses:
+        200:
+          body:
+            text/plain:
+    /followers:
+      displayName: playlist-followers
+      put:
+        description: |
+          [Follow a Playlist](https://developer.spotify.com/web-api/follow-playlist/)
+        securedBy: [ oauth_2_0: { scopes: ["playlist-modify-public", "playlist-modify-private"]}]
+        body:
+          application/json:
+            schema: |
+              {
+                "$schema": "http://json-schema.org/draft-03/schema",
+                "type": "object",
+                "required": false,
+                "properties": {
+                  "public": {
+                    "type": "boolean",
+                    "required": false
+                  }
+                }
+              }
+        responses:
+          200:
+            body:
+              text/plain:
+      delete:
+        description: |
+          [Unfollow a Playlist](https://developer.spotify.com/web-api/unfollow-playlist/)
+        securedBy: [ oauth_2_0: { scopes: ["playlist-modify-public", "playlist-modify-private"]}]
+        responses:
+          200:
+            body:
+              text/plain:
+/me/following:
+  displayName: following
+  put:
+    description: |
+      [Follow Artists or Users](https://developer.spotify.com/web-api/follow-artists-users/)
+    securedBy: [ oauth_2_0: {scopes: ["user-follow-modify"]} ]
+    queryParameters:
+      type:
+        displayName: Item Type
+        description: The type to follow.
+        type: string
+        example: artist
+        enum: ["artist", "user"]
+        required: true
+      ids:
+        displayName: Spotify IDs
+        type: string
+        description: A comma-separated list of the artists or users ids
+        required: true
+        example: "2CIMQHirSU0MQqyYHq0eOx,57dN52uHvrHOxijzpIgu3E,1vCWHaC5f2uS3yhpwWbIA6"
+    responses:
+      204:
+  delete:
+    description: |
+      [Unfollow Artists or Users](https://developer.spotify.com/web-api/unfollow-artists-users/)
+    securedBy: [ oauth_2_0: {scopes: ["user-follow-modify"]} ]
+    queryParameters:
+      type:
+        displayName: Item Type
+        description: The type to unfollow.
+        type: string
+        example: artist
+        enum: ["artist", "user"]
+        required: true
+      ids:
+        displayName: Spotify IDs
+        type: string
+        description: A comma-separated list of the artists or users ids
+        required: true
+        example: "2CIMQHirSU0MQqyYHq0eOx,57dN52uHvrHOxijzpIgu3E,1vCWHaC5f2uS3yhpwWbIA6"
+    responses:
+      204:

--- a/tests/data/examples/test-config.ini
+++ b/tests/data/examples/test-config.ini
@@ -4,7 +4,7 @@ production = True
 
 [custom]
 append = True
-resp_codes = 420, 421, 422
+resp_codes = 420, 421, 422, 429, 430
 auth_schemes = oauth_3_0, oauth_4_0
 media_types = application/vnd.github.v3, foo/bar
 protocols = FTP

--- a/tests/data/validate/empty-mapping-resource-type.raml
+++ b/tests/data/validate/empty-mapping-resource-type.raml
@@ -1,0 +1,210 @@
+#%RAML 0.8
+title: Spotify Web API
+version: v1
+baseUri: https://api.spotify.com/{version}
+mediaType: application/json
+documentation:
+  - title: Spotify Web API Docs
+    content: |
+      Welcome to the _Spotify Web API_ specification. For more information about
+      how to use the API, check out the [Spotify's developer site](https://developer.spotify.com/web-api/).
+resourceTypes:
+  - emptyType:
+securitySchemes:
+  - oauth_2_0:
+      description: |
+          Spotify supports OAuth 2.0 for authenticating all API requests.
+      type: OAuth 2.0
+      describedBy:
+        headers:
+          Authorization:
+            description: |
+              Used to send a valid OAuth 2 access token.
+            type: string
+        responses:
+          401:
+            description: |
+              Bad or expired token. This can happen if the user revoked a token or
+              the access token has expired. You should re-authenticate the user.
+          403:
+            description: |
+              Bad OAuth request (access token without necessary scope).
+      settings:
+        authorizationUri: https://accounts.spotify.com/authorize
+        accessTokenUri: https://accounts.spotify.com/api/token
+        authorizationGrants: [ code, token ]
+        scopes:
+          - "user-library-read"
+          - "user-library-modify"
+          - "user-read-private"
+          - "user-read-birthdate"
+          - "user-read-email"
+          - "user-follow-read"
+          - "user-follow-modify"
+          - "playlist-read-collaborative"
+          - "playlist-read-private"
+          - "playlist-modify-public"
+          - "playlist-modify-private"
+traits:
+  - filterable:
+      queryParameters:
+        fields:
+          description: A comma-separated list of fields to filter query
+          type: string
+          example: items(added_by.id,track(name,href,album(name,href)))
+          displayName: Fields
+  - paged:
+      queryParameters:
+        limit:
+          displayName: Limit
+          description: The maximum number of items to return
+          type: integer
+          example: 10
+          minimum: 0
+          default: 20
+          maximum: 50
+          required: false
+        offset:
+          displayName: Offset
+          description: The index of the first item to return
+          type: integer
+          example: 5
+          default: 0
+          required: false
+/me:
+  displayName: current-user
+  securedBy: [ oauth_2_0: {scopes: ["user-read-private", "user-read-birthdate", "user-read-email"]} ]
+  /tracks:
+    displayName: current-user-saved-tracks
+    type: collection
+    put:
+      description: |
+        [Save Tracks for Current User](https://developer.spotify.com/web-api/save-tracks-user/)
+      securedBy: [ oauth_2_0: {scopes: ["user-library-modify"]}]
+      queryParameters:
+        ids:
+          displayName: Spotify Track IDs
+          type: string
+          description: A comma-separated list of IDs
+          required: true
+          example: "7ouMYWpwJ422jRcDASZB7P,4VqPOruhp5EdPBeR92t6lQ,2takcwOaAZWiXQijPHIx7B"
+      responses:
+        200:
+          body:
+            text/plain:
+    delete:
+      description: |
+        [Remove Tracks for Current User](https://developer.spotify.com/web-api/remove-tracks-user/)
+      securedBy: [ oauth_2_0: {scopes: ["user-library-modify"]}]
+      queryParameters:
+        ids:
+          displayName: Spotify Track IDs
+          type: string
+          description: A comma-separated list of IDs
+          required: true
+          example: "7ouMYWpwJ422jRcDASZB7P,4VqPOruhp5EdPBeR92t6lQ,2takcwOaAZWiXQijPHIx7B"
+      responses:
+        200:
+          body:
+            text/plain:
+/users/{user_id}/playlists:
+  type: collection
+  uriParameters:
+    user_id:
+      displayName: Owner ID
+      type: string
+      description: The user's Spotify user ID.
+      example: jmperezperez
+  displayName: playlists
+  /{playlist_id}:
+    type: item
+    displayName: playlist
+    uriParameters:
+      playlist_id:
+        displayName: Playlist ID
+        description: The Spotify playlist ID.
+        example: 3cEYpjA9oz9GiPac4AsH4n
+        type: string
+        required: true
+    put:
+      description: |
+        [Change a Playlist's Details](https://developer.spotify.com/web-api/change-playlist-details/)
+      securedBy: [ oauth_2_0: { scopes: ["playlist-modify-public", "playlist-modify-private"]}]
+      responses:
+        200:
+          body:
+            text/plain:
+    /followers:
+      displayName: playlist-followers
+      put:
+        description: |
+          [Follow a Playlist](https://developer.spotify.com/web-api/follow-playlist/)
+        securedBy: [ oauth_2_0: { scopes: ["playlist-modify-public", "playlist-modify-private"]}]
+        body:
+          application/json:
+            schema: |
+              {
+                "$schema": "http://json-schema.org/draft-03/schema",
+                "type": "object",
+                "required": false,
+                "properties": {
+                  "public": {
+                    "type": "boolean",
+                    "required": false
+                  }
+                }
+              }
+        responses:
+          200:
+            body:
+              text/plain:
+      delete:
+        description: |
+          [Unfollow a Playlist](https://developer.spotify.com/web-api/unfollow-playlist/)
+        securedBy: [ oauth_2_0: { scopes: ["playlist-modify-public", "playlist-modify-private"]}]
+        responses:
+          200:
+            body:
+              text/plain:
+/me/following:
+  displayName: following
+  put:
+    description: |
+      [Follow Artists or Users](https://developer.spotify.com/web-api/follow-artists-users/)
+    securedBy: [ oauth_2_0: {scopes: ["user-follow-modify"]} ]
+    queryParameters:
+      type:
+        displayName: Item Type
+        description: The type to follow.
+        type: string
+        example: artist
+        enum: ["artist", "user"]
+        required: true
+      ids:
+        displayName: Spotify IDs
+        type: string
+        description: A comma-separated list of the artists or users ids
+        required: true
+        example: "2CIMQHirSU0MQqyYHq0eOx,57dN52uHvrHOxijzpIgu3E,1vCWHaC5f2uS3yhpwWbIA6"
+    responses:
+      204:
+  delete:
+    description: |
+      [Unfollow Artists or Users](https://developer.spotify.com/web-api/unfollow-artists-users/)
+    securedBy: [ oauth_2_0: {scopes: ["user-follow-modify"]} ]
+    queryParameters:
+      type:
+        displayName: Item Type
+        description: The type to unfollow.
+        type: string
+        example: artist
+        enum: ["artist", "user"]
+        required: true
+      ids:
+        displayName: Spotify IDs
+        type: string
+        description: A comma-separated list of the artists or users ids
+        required: true
+        example: "2CIMQHirSU0MQqyYHq0eOx,57dN52uHvrHOxijzpIgu3E,1vCWHaC5f2uS3yhpwWbIA6"
+    responses:
+      204:

--- a/tests/data/validate/empty-mapping-security-scheme-settings.raml
+++ b/tests/data/validate/empty-mapping-security-scheme-settings.raml
@@ -1,0 +1,202 @@
+#%RAML 0.8
+title: Spotify Web API
+version: v1
+baseUri: https://api.spotify.com/{version}
+mediaType: application/json
+documentation:
+  - title: Spotify Web API Docs
+    content: |
+      Welcome to the _Spotify Web API_ specification. For more information about
+      how to use the API, check out the [Spotify's developer site](https://developer.spotify.com/web-api/).
+resourceTypes:
+  - base:
+      get?: &common
+        headers:
+          Accept:
+            description: It is used to set specified media type.
+            type: string
+          EmptyAccept:
+          EmptyAcceptParams:
+            description:
+        responses:
+          429:
+            description: |
+              API rate limit exceeded. See http://developer.spotify.com/web-api/user-guide/#rate-limiting for details.
+          430:
+      post?: *common
+      put?: *common
+      delete?: *common
+  - item:
+      type: base
+      get?:
+  - collection:
+      type: base
+      get?:
+securitySchemes:
+  - EmptySettingsScheme:
+      description: Security Scheme with empty settings
+      type: custom
+      settings:
+traits:
+  - filterable:
+      queryParameters:
+        fields:
+          description: A comma-separated list of fields to filter query
+          type: string
+          example: items(added_by.id,track(name,href,album(name,href)))
+          displayName: Fields
+  - paged:
+      queryParameters:
+        limit:
+          displayName: Limit
+          description: The maximum number of items to return
+          type: integer
+          example: 10
+          minimum: 0
+          default: 20
+          maximum: 50
+          required: false
+        offset:
+          displayName: Offset
+          description: The index of the first item to return
+          type: integer
+          example: 5
+          default: 0
+          required: false
+/me:
+  displayName: current-user
+  securedBy: [ oauth_2_0: {scopes: ["user-read-private", "user-read-birthdate", "user-read-email"]} ]
+  /tracks:
+    displayName: current-user-saved-tracks
+    type: collection
+    put:
+      description: |
+        [Save Tracks for Current User](https://developer.spotify.com/web-api/save-tracks-user/)
+      securedBy: [ oauth_2_0: {scopes: ["user-library-modify"]}]
+      queryParameters:
+        ids:
+          displayName: Spotify Track IDs
+          type: string
+          description: A comma-separated list of IDs
+          required: true
+          example: "7ouMYWpwJ422jRcDASZB7P,4VqPOruhp5EdPBeR92t6lQ,2takcwOaAZWiXQijPHIx7B"
+      responses:
+        200:
+          body:
+            text/plain:
+    delete:
+      description: |
+        [Remove Tracks for Current User](https://developer.spotify.com/web-api/remove-tracks-user/)
+      securedBy: [ oauth_2_0: {scopes: ["user-library-modify"]}]
+      queryParameters:
+        ids:
+          displayName: Spotify Track IDs
+          type: string
+          description: A comma-separated list of IDs
+          required: true
+          example: "7ouMYWpwJ422jRcDASZB7P,4VqPOruhp5EdPBeR92t6lQ,2takcwOaAZWiXQijPHIx7B"
+      responses:
+        200:
+          body:
+            text/plain:
+/users/{user_id}/playlists:
+  type: collection
+  uriParameters:
+    user_id:
+      displayName: Owner ID
+      type: string
+      description: The user's Spotify user ID.
+      example: jmperezperez
+  displayName: playlists
+  /{playlist_id}:
+    type: item
+    displayName: playlist
+    uriParameters:
+      playlist_id:
+        displayName: Playlist ID
+        description: The Spotify playlist ID.
+        example: 3cEYpjA9oz9GiPac4AsH4n
+        type: string
+        required: true
+    put:
+      description: |
+        [Change a Playlist's Details](https://developer.spotify.com/web-api/change-playlist-details/)
+      securedBy: [ oauth_2_0: { scopes: ["playlist-modify-public", "playlist-modify-private"]}]
+      responses:
+        200:
+          body:
+            text/plain:
+    /followers:
+      displayName: playlist-followers
+      put:
+        description: |
+          [Follow a Playlist](https://developer.spotify.com/web-api/follow-playlist/)
+        securedBy: [ oauth_2_0: { scopes: ["playlist-modify-public", "playlist-modify-private"]}]
+        body:
+          application/json:
+            schema: |
+              {
+                "$schema": "http://json-schema.org/draft-03/schema",
+                "type": "object",
+                "required": false,
+                "properties": {
+                  "public": {
+                    "type": "boolean",
+                    "required": false
+                  }
+                }
+              }
+        responses:
+          200:
+            body:
+              text/plain:
+      delete:
+        description: |
+          [Unfollow a Playlist](https://developer.spotify.com/web-api/unfollow-playlist/)
+        securedBy: [ oauth_2_0: { scopes: ["playlist-modify-public", "playlist-modify-private"]}]
+        responses:
+          200:
+            body:
+              text/plain:
+/me/following:
+  displayName: following
+  put:
+    description: |
+      [Follow Artists or Users](https://developer.spotify.com/web-api/follow-artists-users/)
+    securedBy: [ oauth_2_0: {scopes: ["user-follow-modify"]} ]
+    queryParameters:
+      type:
+        displayName: Item Type
+        description: The type to follow.
+        type: string
+        example: artist
+        enum: ["artist", "user"]
+        required: true
+      ids:
+        displayName: Spotify IDs
+        type: string
+        description: A comma-separated list of the artists or users ids
+        required: true
+        example: "2CIMQHirSU0MQqyYHq0eOx,57dN52uHvrHOxijzpIgu3E,1vCWHaC5f2uS3yhpwWbIA6"
+    responses:
+      204:
+  delete:
+    description: |
+      [Unfollow Artists or Users](https://developer.spotify.com/web-api/unfollow-artists-users/)
+    securedBy: [ oauth_2_0: {scopes: ["user-follow-modify"]} ]
+    queryParameters:
+      type:
+        displayName: Item Type
+        description: The type to unfollow.
+        type: string
+        example: artist
+        enum: ["artist", "user"]
+        required: true
+      ids:
+        displayName: Spotify IDs
+        type: string
+        description: A comma-separated list of the artists or users ids
+        required: true
+        example: "2CIMQHirSU0MQqyYHq0eOx,57dN52uHvrHOxijzpIgu3E,1vCWHaC5f2uS3yhpwWbIA6"
+    responses:
+      204:

--- a/tests/data/validate/empty-mapping-trait.raml
+++ b/tests/data/validate/empty-mapping-trait.raml
@@ -1,0 +1,110 @@
+#%RAML 0.8
+title: Spotify Web API
+version: v1
+baseUri: https://api.spotify.com/{version}
+mediaType: application/json
+documentation:
+  - title: Spotify Web API Docs
+    content: |
+      Welcome to the _Spotify Web API_ specification. For more information about
+      how to use the API, check out the [Spotify's developer site](https://developer.spotify.com/web-api/).
+resourceTypes:
+  - base:
+      get?: &common
+        headers:
+          Accept:
+            description: It is used to set specified media type.
+            type: string
+          EmptyAccept:
+          EmptyAcceptParams:
+            description:
+        responses:
+          429:
+            description: |
+              API rate limit exceeded. See http://developer.spotify.com/web-api/user-guide/#rate-limiting for details.
+          430:
+      post?: *common
+      put?: *common
+      delete?: *common
+  - item:
+      type: base
+      get?:
+securitySchemes:
+  - oauth_2_0:
+      description: |
+          Spotify supports OAuth 2.0 for authenticating all API requests.
+      type: OAuth 2.0
+      describedBy:
+        headers:
+          Authorization:
+            description: |
+              Used to send a valid OAuth 2 access token.
+            type: string
+        responses:
+          401:
+            description: |
+              Bad or expired token. This can happen if the user revoked a token or
+              the access token has expired. You should re-authenticate the user.
+          403:
+            description: |
+              Bad OAuth request (access token without necessary scope).
+      settings:
+        authorizationUri: https://accounts.spotify.com/authorize
+        accessTokenUri: https://accounts.spotify.com/api/token
+        authorizationGrants: [ code, token ]
+        scopes:
+          - "user-library-read"
+          - "user-library-modify"
+          - "user-read-private"
+          - "user-read-birthdate"
+          - "user-read-email"
+          - "user-follow-read"
+          - "user-follow-modify"
+          - "playlist-read-collaborative"
+          - "playlist-read-private"
+          - "playlist-modify-public"
+          - "playlist-modify-private"
+traits:
+  - emptyTrait:
+  - filterable:
+      queryParameters:
+        fields:
+          description: A comma-separated list of fields to filter query
+          type: string
+          example: items(added_by.id,track(name,href,album(name,href)))
+          displayName: Fields
+  - paged:
+      queryParameters:
+        limit:
+          displayName: Limit
+          description: The maximum number of items to return
+          type: integer
+          example: 10
+          minimum: 0
+          default: 20
+          maximum: 50
+          required: false
+        offset:
+          displayName: Offset
+          description: The index of the first item to return
+          type: integer
+          example: 5
+          default: 0
+          required: false
+/me:
+  displayName: current-user
+  securedBy: [ oauth_2_0: {scopes: ["user-read-private", "user-read-birthdate", "user-read-email"]} ]
+  /tracks:
+    displayName: current-user-saved-tracks
+    type: collection
+    put:
+      description: |
+        [Save Tracks for Current User](https://developer.spotify.com/web-api/save-tracks-user/)
+      securedBy: [ oauth_2_0: {scopes: ["user-library-modify"]}]
+      queryParameters:
+        ids:
+          displayName: Spotify Track IDs
+          type: string
+          description: A comma-separated list of IDs
+          required: true
+          example: "7ouMYWpwJ422jRcDASZB7P,4VqPOruhp5EdPBeR92t6lQ,2takcwOaAZWiXQijPHIx7B"

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -213,7 +213,9 @@ def test_trait_filterable(traits):
     assert state.default == "open"
     assert state.required
     assert state.type == "string"
-    assert state.description.raw is None
+    assert state.description is None
+    assert not hasattr(state.description, "raw")
+    assert not hasattr(state.description, "html")
 
     label = trait.query_params[2]
     assert label.name == "labels"
@@ -229,14 +231,18 @@ def test_trait_filterable(traits):
     assert sort.default == "created"
     assert sort.required
     assert sort.type == "string"
-    assert sort.description.raw is None
+    assert sort.description is None
+    assert not hasattr(sort.description, "raw")
+    assert not hasattr(sort.description, "html")
 
     direction = trait.query_params[4]
     assert direction.name == "direction"
     assert direction.enum == ["asc", "desc"]
     assert direction.default == "desc"
     assert direction.required
-    assert direction.description.raw is None
+    assert direction.description is None
+    assert not hasattr(direction.description, "raw")
+    assert not hasattr(direction.description, "html")
 
     since = trait.query_params[5]
     assert since.name == "since"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -86,8 +86,9 @@ def test_uri_params(root):
     assert root.uri_params[0].display_name == "Community Path"
     assert root.uri_params[0].type == "string"
     assert root.uri_params[0].min_length == 1
-    assert root.uri_params[0].description.raw is None
-    assert root.uri_params[0].description.html is None
+    assert root.uri_params[0].description is None
+    assert not hasattr(root.uri_params[0].description, "raw")
+    assert not hasattr(root.uri_params[0].description, "html")
     assert root.uri_params[0].default is None
     assert root.uri_params[0].enum is None
     assert root.uri_params[0].example is None
@@ -187,7 +188,7 @@ def sec_schemes():
 
 
 def test_create_security_schemes(sec_schemes):
-    assert len(sec_schemes) == 2
+    assert len(sec_schemes) == 3
     assert sec_schemes[0].name == "oauth_2_0"
     assert sec_schemes[0].type == "OAuth 2.0"
 
@@ -245,6 +246,13 @@ def test_create_security_schemes_custom(sec_schemes):
 
     assert custom.documentation[0].title.raw == "foo docs"
     assert custom.documentation[0].content.raw == "foo content"
+
+
+def test_security_scheme_no_desc(sec_schemes):
+    no_desc = sec_schemes[2]
+
+    assert no_desc.name == "no_desc"
+    assert no_desc.description is None
 
 
 #####
@@ -553,6 +561,34 @@ def test_resource_type_secured_by(resource_types):
     assert scheme.settings == settings
 
 
+def test_resource_type_empty_mapping():
+    raml_file = os.path.join(EXAMPLES + "empty-mapping-resource-type.raml")
+    loaded_raml_file = load_file(raml_file)
+    config = setup_config(EXAMPLES + "test-config.ini")
+    config['validate'] = False
+    api = pw.parse_raml(loaded_raml_file, config)
+
+    assert len(api.resource_types) == 1
+
+    res = api.resource_types[0]
+
+    assert res.name == "emptyType"
+    assert res.raw == {}
+
+
+def test_resource_type_empty_mapping_headers():
+    raml_file = os.path.join(EXAMPLES + "empty-mapping.raml")
+    loaded_raml_file = load_file(raml_file)
+    config = setup_config(EXAMPLES + "test-config.ini")
+    config['validate'] = False
+    api = pw.parse_raml(loaded_raml_file, config)
+
+    base_res_type = api.resource_types[0]
+
+    assert len(base_res_type.headers) == 3
+    assert base_res_type.headers[-1].description is None
+
+
 #####
 # Test Resources
 #####
@@ -804,6 +840,20 @@ def test_resource_security_scheme(resources):
 def test_resource_inherit_parent(resources):
     res = resources[2]
     assert len(res.uri_params) == 4
+
+
+def test_resource_response_no_desc():
+    raml_file = os.path.join(EXAMPLES + "empty-mapping.raml")
+    loaded_raml_file = load_file(raml_file)
+    config = setup_config(EXAMPLES + "test-config.ini")
+    config['validate'] = False
+    api = pw.parse_raml(loaded_raml_file, config)
+
+    res = api.resources[-1]
+    response = res.responses[-1]
+
+    assert response.code == 204
+    assert response.description is None
 
 
 #####

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -300,3 +300,39 @@ def test_invalid_string_type():
     msg = ("invalidParamType must be a string type to have min_length "
            "attribute set, not 'integer'.",)
     assert msg == e.value.args
+
+
+#####
+# ResourceType, Trait, and Security Scheme validators
+#####
+
+def test_empty_mapping_res_type():
+    raml = load_raml("empty-mapping-resource-type.raml")
+    config = load_config("valid-config.ini")
+    with pytest.raises(errors.InvalidResourceNodeError) as e:
+        parse(raml, config)
+
+    msg = ("The resourceType 'emptyType' requires definition.",)
+    assert e.value.args == msg
+
+
+def test_empty_mapping_trait():
+    raml = load_raml("empty-mapping-trait.raml")
+    config = load_config("valid-config.ini")
+    with pytest.raises(errors.InvalidResourceNodeError) as e:
+        parse(raml, config)
+
+    msg = ("The trait 'emptyTrait' requires definition.",)
+    assert e.value.args == msg
+
+
+def test_empty_mapping_sec_scheme_settings():
+    _raml = "empty-mapping-security-scheme-settings.raml"
+    raml = load_raml(_raml)
+    config = load_config("valid-config.ini")
+    with pytest.raises(errors.InvalidSecuritySchemeError) as e:
+        parse(raml, config)
+
+    msg = ("'settings' for security scheme 'EmptySettingsScheme' require "
+           "definition.",)
+    assert e.value.args == msg


### PR DESCRIPTION
Addresses #30 

When a RAML file has an empty mapping, parser.py would error out, which is now caught.  Created some validation checks when resource type/traits/security scheme settings are an empty map (a judgment call because not explicitly stated in spec).

(sorry for the extra commits - had done some reordering :-/)