### PR TITLE
Fix PyPI automatic upload

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Developer Setup
 If you'd like to contribute or develop upon ``ramlfications``, be sure to read `How to Contribute`_
 first.
 
-You can see the progress of ``ramlfications`` on our `waffle.io`_ page.
+You can see the progress of ``ramlfications`` on our public `project management`_ page.
 
 System requirements:
 ^^^^^^^^^^^^^^^^^^^^
@@ -132,4 +132,4 @@ Feel free to drop by ``#ramlfications`` on Freenode (`webchat`_) or ping via `Tw
 .. _`webchat`: http://webchat.freenode.net?channels=%23ramlfications&uio=ND10cnVlJjk9dHJ1ZQb4
 .. _`econchick`: https://github.com/econchick
 .. _`Twitter`: https://twitter.com/roguelynn
-.. _`waffle.io`: https://waffle.io/spotify/ramlfications
+.. _`project management`: https://waffle.io/spotify/ramlfications

--- a/setup.py
+++ b/setup.py
@@ -89,10 +89,10 @@ setup(
         ]
     },
     classifiers=[
-        "Development Status :: 4 – Beta",
+        "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Natural Language :: English",
-        "License :: Apache License 2.0",
+        "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",


### PR DESCRIPTION
Correct invalid setup.py classifiers; fix rST parsing

This was what stopped the register/upload to PyPI via command line.  Tested on PyPI's test servers (both register/upload and download).  Also, fixed an error that `python setup.py check -r -m` returned when parsing rST parsing.