### PR TITLE
select resourse type based on resourse type and http method

### DIFF
--- a/ramlfications/parser.py
+++ b/ramlfications/parser.py
@@ -1233,7 +1233,7 @@ def create_node(name, raw_data, method, parent, root):
         if type_() and root.resource_types:
             assigned_name = type_()
             res_types = root.resource_types
-            type_obj = [r for r in res_types if r.name == assigned_name]
+            type_obj = [r for r in res_types if r.name == assigned_name and r.method == method]
             if type_obj:
                 return type_obj[0]
 


### PR DESCRIPTION
If resourceTypes item contains few HTTP methods ramlfications will create few ResourceTypeNodes, each per method. But all of them will have same name and current implementation of assigning resource's resource type object just select first ResourceTypeNode.

I propose to check HTTP method for assigning resource type.