### PR TITLE
Partial fix for #23 - incorrect resource type inheritance

### DIFF
--- a/ramlfications/parameters.py
+++ b/ramlfications/parameters.py
@@ -13,6 +13,12 @@ HTTP_METHODS = [
     "head", "trace", "connect"
 ]
 
+NAMED_PARAMS = [
+    "desc", "type", "enum", "pattern", "minimum", "maximum", "example",
+    "default", "required", "repeat", "display_name", "max_length",
+    "min_length"
+]
+
 
 class Content(object):
     """
@@ -100,6 +106,16 @@ class BaseParameter(object):
         if self.desc:
             return Content(self.desc)
         return None
+
+    def _inherit_type_properties(self, inherited_param):
+        for param in inherited_param:
+            name = getattr(param, "name", getattr(param, "code", None))
+            if name == self.name:
+                for n in NAMED_PARAMS:
+                    attr = getattr(self, n, None)
+                    if attr is None:
+                        attr = getattr(param, n, None)
+                        setattr(self, n, attr)
 
 
 @attr.s
@@ -226,6 +242,15 @@ class Header(object):
             return Content(self.desc)
         return None
 
+    def _inherit_type_properties(self, inherited_param):
+        params = NAMED_PARAMS + ["method"]
+        for param in inherited_param:
+            for n in params:
+                attr = getattr(self, n, None)
+                if attr is None:
+                    attr = getattr(param, n, None)
+                    setattr(self, n, attr)
+
 
 @attr.s
 class Body(object):
@@ -256,6 +281,17 @@ class Body(object):
                           validator=attr.validators.instance_of(dict))
     errors      = attr.ib(repr=False)
 
+    def _inherit_type_properties(self, inherited_param):
+        body_params = ["schema", "example", "form_params"]
+        for param in inherited_param:
+            if param.mime_type != self.mime_type:
+                continue
+            for n in body_params:
+                attr = getattr(self, n, None)
+                if attr is None:
+                    attr = getattr(param, n, None)
+                    setattr(self, n, attr)
+
 
 @attr.s
 class Response(object):
@@ -285,6 +321,14 @@ class Response(object):
         if self.desc:
             return Content(self.desc)
         return None
+
+    def _inherit_type_properties(self, inherited_param):
+        for param in inherited_param:
+            for n in NAMED_PARAMS:
+                attr = getattr(self, n, None)
+                if attr is None:
+                    attr = getattr(param, n, None)
+                    setattr(self, n, attr)
 
 
 @attr.s

--- a/ramlfications/raml.py
+++ b/ramlfications/raml.py
@@ -15,6 +15,10 @@ AVAILABLE_METHODS = [
     "trace", "connect"
 ]
 
+METHOD_PROPERTIES = [
+    "headers", "body", "responses", "query_params", "form_params"
+]
+
 
 @attr.s
 class RootNode(object):
@@ -202,3 +206,11 @@ class ResourceNode(BaseNode):
     resource_type    = attr.ib(repr=False)
     secured_by       = attr.ib(repr=False)
     security_schemes = attr.ib(repr=False)
+
+    def _inherit_type(self):
+        for p in METHOD_PROPERTIES:
+            inherited_prop = getattr(self.resource_type, p)
+            resource_prop = getattr(self, p)
+            if resource_prop and inherited_prop:
+                for r in resource_prop:
+                    r._inherit_type_properties(inherited_prop)

--- a/ramlfications/utils.py
+++ b/ramlfications/utils.py
@@ -181,3 +181,17 @@ def update_mime_types():
     _save_updated_mime_types(output_file, mime_types)
 
     log.debug("Done! Supported IANA MIME media types have been updated.")
+
+
+def _resource_type_lookup(assigned, root):
+    """
+    Returns ``ResourceType`` object
+
+    :param str assigned: The string name of the assigned resource type
+    :param root: RAML root object
+    """
+    res_types = root.resource_types
+    if res_types:
+        res_type_obj = [r for r in res_types if r.name == assigned]
+        if res_type_obj:
+            return res_type_obj[0]

--- a/tests/data/examples/includes/inherited.example.json
+++ b/tests/data/examples/includes/inherited.example.json
@@ -1,0 +1,6 @@
+{
+    "name": "A Name",
+    "popularity": 1,
+    "type": "artist",
+    "uri": "uri:to:artistname"
+}

--- a/tests/data/examples/includes/inherited.schema.json
+++ b/tests/data/examples/includes/inherited.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the artist."
+    },
+    "popularity": {
+      "type": "integer",
+      "description": "The popularity of the artist. The value will be between 0 and 100, with 100 being the most popular. The artist's popularity is calculated from the popularity of all the artist's tracks."
+    },
+    "type": {
+      "type": "string",
+      "description": "The object type: 'artist'"
+    },
+    "uri": {
+      "type": "string",
+      "description": "The Spotify URI for the artist."
+    }
+  }
+}

--- a/tests/data/examples/resource-type-inherited.raml
+++ b/tests/data/examples/resource-type-inherited.raml
@@ -1,0 +1,180 @@
+#%RAML 0.8
+---
+title: Example API
+baseUri: http://example.com
+version: v1
+resourceTypes:
+  - inheritgetmethod:
+      description: get-method resource type example
+      usage: Some sort of usage description
+      get:
+        description: This description should be inherited when applied to resources
+        headers:
+          X-Inherited-Header:
+            description: This header should be inherited
+        body:
+          application/json:
+            schema: !include includes/inherited.schema.json
+            example: !include includes/inherited.example.json
+        responses:
+          200:
+            description: Inherited OK response
+          404:
+            description: Inherited resource not found response
+        queryParameters:
+          inherited_param:
+            displayName: inherited query parameter for a get method
+            type: string
+            description: description for inherited query param
+            example: fooBar
+            minLength: 1
+            maxLength: 50
+            required: true
+  - inheritgetoptionalmethod:
+      description: optional get-method resource type example
+      usage: Some sort of usage description
+      get?:
+        description: This description should be inherited when applied to resources with get methods
+        headers:
+          X-Optional-Inherited-Header:
+            description: This header should be inherited when resource has get method
+        queryParameters:
+          another_inherited_param:
+            displayName: another inherited query parameter for a get method
+            type: string
+            description: description for another inherited query param
+            example: barBaz
+            minLength: 2
+            maxLength: 5
+            required: true
+  - partialinherit:
+      description: Some aspects of this resource type will be overwritten
+      get:
+        description: Do not inherit this method-level description
+        headers:
+          X-Inherited-Header:
+            description: this header is inherited
+          X-Overwritten-Header:
+            description: this header description should not be inherited
+            required: false
+        queryParameters:
+          inherited:
+            description: An inherited parameter
+          overwritten:
+            description: Do not inherit this query param description
+            example: This example should be inherited
+        formParameters:
+          overwritten:
+            description: This description should be inherited
+            type: string
+            example: This example should not be inherited
+            minLength: 0
+            maxLength: 5
+        body:
+          application/json:
+            schema: |
+              {
+                "$schema": "http://json-schema.org/draft-03/schema",
+                "type": "object",
+                "properties": {
+                  "inherited": {
+                    "description": "this schema should be inherited"
+                  }
+                }
+              }
+            example: |
+              {
+                "inherited": "yes please!"
+              }
+          text/xml:
+            schema: |
+              <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                <xs:include schemaLocation="./thingy.xsd"/>
+                <xs:element name="thingies">
+                  <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                      <xs:element type="thingyType" name="thingy"/>
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:element>
+              </xs:schema>
+            example: |
+              <thingies>
+                <thingy><name>These should be overwritten!</name></thingy>
+                <thingy><name>Nothing to see here!</name></thingy>
+              </thingies>
+
+        responses:
+          200:
+            description: this 200 response description should not be inherited
+            headers:
+              X-Inherited-Success:
+                description: inherited success response header
+              X-Overwritten-Success:
+                description: this description should not be inherited
+          201:
+            description: This 201 response description should be inherited
+            body:
+              application/json:
+                example: |
+                  {
+                    "description": "I shouldn't see this example"
+                  }
+
+/a-get-resource:
+  description: Resource inherits from inheritedgetmethod
+  type: inheritgetmethod
+/a-post-resource:
+  type: inheritgetoptionalmethod
+  description: |
+    Resource is labeled to inherit from inheritedoptionalmethod but does not define a get method
+  post:
+    description: post some foobar
+/another-get-resource:
+  description: Resource inherits from inheritoptionalmethod
+  type: inheritgetoptionalmethod
+  get:
+    headers:
+      X-Non-Inherited-Header:
+        description: This is a header in addition to what is inherited
+/another-post-resource:
+  type: inheritgetmethod
+  description: This resource should also inherit the Resource Type's get method properties
+  post:
+    description: post some more foobar
+/inherit-no-overwrite:
+  type: partialinherit
+  description: Resource defines some resource type properties
+  get:
+    description: This method-level description should be used
+    headers:
+      X-Overwritten-Header:
+        description: This header description should be used
+        required: true
+    queryParameters:
+      overwritten:
+        description: This query param description should be used
+    formParameters:
+      overwritten:
+        example: This example for the overwritten form param should be used
+        minLength: 1
+    body:
+      text/xml:
+        example: |
+          <thingies>
+            <thingy><name>Successfully overwrote body XML example</name></thingy>
+          </thingies>
+
+    responses:
+      200:
+        description: overwriting the 200 response description
+        headers:
+          X-Overwritten-Success:
+            description:  overwritten success response header
+      201:
+        body:
+          application/json:
+            example: |
+              {
+                "description": "overwritten description of 201 body example"
+              }


### PR DESCRIPTION
* When a resource type is defined with one method that is optional and is applied to a resource that does *not* have that method defined, the resource’s method should not inherit from the optional method
* When a resource inherits a resource type but explicitly defines named parameters, the named parameters in the resource should overwrite those that are inherited

Inheritance order of traits and handling resource *types* inheriting other resource types still in progress.