### PR TITLE
Added class NodeList

### DIFF
--- a/ramlfications/__init__.py
+++ b/ramlfications/__init__.py
@@ -3,6 +3,10 @@
 
 from __future__ import absolute_import, division, print_function
 
+from ramlfications.config import setup_config
+from ramlfications.parser import parse_raml
+from ramlfications._helpers import load_file, load_string
+
 __author__ = "Lynn Root"
 __version__ = "0.1.9"
 __license__ = "Apache 2.0"
@@ -10,12 +14,6 @@ __license__ = "Apache 2.0"
 __email__ = "lynn@spotify.com"
 __uri__ = "https://ramlfications.readthedocs.org"
 __description__ = "A Python RAML parser"
-
-
-from ramlfications.config import setup_config
-from ramlfications.parser import parse_raml
-
-from ramlfications._helpers import load_file, load_string
 
 
 def load(raml_file):

--- a/ramlfications/_compat.py
+++ b/ramlfications/_compat.py
@@ -1,0 +1,16 @@
+import sys
+
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict  # noqa
+
+
+if PY3:
+    open = open
+else:
+    from io import open  # noqa

--- a/ramlfications/_helpers.py
+++ b/ramlfications/_helpers.py
@@ -1,16 +1,12 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2015 Spotify AB
-import sys
-
-if sys.version_info[0] == 2:
-    from io import open
-
 import os
 
 import six
 
 from .errors import LoadRAMLError
 from .loader import RAMLLoader
+from ._compat import open
 
 
 def load_file(raml_file):

--- a/ramlfications/errors.py
+++ b/ramlfications/errors.py
@@ -59,3 +59,19 @@ class LoadRAMLError(Exception):
 
 class MediaTypeError(Exception):
     pass
+
+
+###
+# NodeList exceptions
+###
+
+class InvalidNodeListFilterKey(Exception):
+    """When an invalid filter key was passed in to a NodeList"""
+
+
+class MultipleNodesFound(Exception):
+    """A single node was required but more than one were found."""
+
+
+class NoNodeFound(Exception):
+    """One node was required but none was found."""

--- a/ramlfications/loader.py
+++ b/ramlfications/loader.py
@@ -1,19 +1,15 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2015 Spotify AB
 
-__all__ = ["RAMLLoader"]
-
-try:
-    from collections import OrderedDict
-except ImportError:  # pragma: no cover
-    from ordereddict import OrderedDict
-
 import os
 
 import jsonref
 import yaml
 
 from .errors import LoadRAMLError
+from ._compat import OrderedDict
+
+__all__ = ["RAMLLoader"]
 
 
 class RAMLLoader(object):

--- a/ramlfications/nodelist.py
+++ b/ramlfications/nodelist.py
@@ -1,0 +1,105 @@
+from . import errors
+
+
+class NodeList(list):
+    """List with attribute filtering capabilities
+
+        Example::
+
+            class Person(object):
+                def __init__(self, first_name, last_name):
+                    self.first_name = first_name
+                    self.last_name = last_name
+
+            >>> musk = Person(first_name='Elon', last_name='Musk')
+            >>> torvalds = Person(first_name='Linus', last_name='Torvalds')
+            >>> svensson = Person(first_name='Linus', last_name='Svensson')
+            >>> persons = NodeList([musk, torvalds, svensson])
+
+            >>> persons.first()
+            Person('Elon Musk')
+
+            >>> linuses = persons.filter_by(first_name='Linus')
+            FilteredList([Person('Linus Torvalds'), Person('Linus Svensson')])
+
+            >>> linuses.filter_by(last_name='Svensson').one()
+            Person('Linus Svensson')
+
+            >>> linuses.first()
+            Person('Linus Torvalds')
+    """
+
+    def __repr__(self):
+        return 'NodeList({0})'.format(super(NodeList, self).__repr__())
+
+    def filter_by(self, **filters):
+        """
+        Filter the list's objects based on their attributes' values, or their
+        keys' values if the objects are instances of :py:class:`dict`.
+
+        Args:
+            filters (dict):
+                A dictionary that should be used for filtering the list's
+                objects. The keys should correspond to the objects attributes.
+        Raises:
+            :py:class:`InvalidNodeListFilterKey`:
+                When a filter key is passed in that could not be matched
+                to any of the child's attributes.
+        Returns:
+            :py:class:`NodeList`:
+                The new filtered list.
+        """
+        new_nodes = NodeList()
+        is_dict = None
+        for i, node in enumerate(self):
+            if i == 0:
+                is_dict = isinstance(node, dict)
+            num_matches = 0
+            for attr_name, value in filters.items():
+                try:
+                    if is_dict:
+                        attr = node[attr_name]
+                    else:
+                        attr = getattr(node, attr_name)
+                except (AttributeError, KeyError) as exc:
+                    raise errors.InvalidNodeListFilterKey(*exc.args)
+                if attr == value:
+                    num_matches += 1
+            if num_matches == len(filters):
+                new_nodes.append(node)
+        return new_nodes
+
+    def one(self):
+        """
+        Get one item in the list, or raise an exception if less or more than
+        one item was found.
+
+        Raises:
+            :py:class:`NoNodeFound`:
+                When no node was found.
+            :py:class:`MultipleNodesFound`:
+                When multiple nodes were found.
+        Returns:
+            Any:
+                The first node in the list.
+        """
+        if len(self) > 1:
+            raise errors.MultipleNodesFound(
+                'Multiple nodes were found for one()'
+            )
+        try:
+            return self[0]
+        except IndexError:
+            raise errors.NoNodeFound('No node was found for one()')
+
+    def first(self):
+        """Like one(), but doesn't raise any exception.
+
+        Returns:
+            Any:
+                The first node in the list, or `None` if no node was found.
+        """
+        try:
+            return self[0]
+        except IndexError:
+            return None

--- a/ramlfications/parser_utils.py
+++ b/ramlfications/parser_utils.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 from six import itervalues, iterkeys
 
+from .nodelist import NodeList
 from .parameters import SecurityScheme
 from .utils import _get_scheme
 # functions used to parse the same shit in parser.py
@@ -15,7 +16,7 @@ from .utils import _get_scheme
 def security_schemes(secured, root):
     """Set resource's assigned security scheme objects."""
     if secured:
-        secured_objs = []
+        secured_objs = NodeList()
         for item in secured:
             assigned_scheme = _get_scheme(item, root)
             if assigned_scheme:

--- a/ramlfications/tree.py
+++ b/ramlfications/tree.py
@@ -3,11 +3,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-try:
-    from collections import OrderedDict
-except ImportError:  # pragma: no cover
-    from ordereddict import OrderedDict  # pragma: no cover
-
 import sys
 
 from six import iteritems, itervalues
@@ -15,6 +10,7 @@ from termcolor import colored
 
 from .config import setup_config
 from .parser import parse_raml
+from ._compat import OrderedDict
 
 COLOR_MAP = {
     "light": (('white', None),

--- a/ramlfications/utils.py
+++ b/ramlfications/utils.py
@@ -3,24 +3,21 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 import json
 import logging
 import os
 import re
 import sys
 
-try:
-    from collections import OrderedDict
-except ImportError:  # NOCOV
-    from ordereddict import OrderedDict
-
-from six import iterkeys, iteritems
 import xmltodict
+from six import iterkeys, iteritems
 
+from .errors import MediaTypeError
+from .nodelist import NodeList
 from .parameters import (
     Body, URIParameter, Header, FormParameter, QueryParameter
 )
+from ._compat import OrderedDict
 
 PYVER = sys.version_info[:3]
 
@@ -39,8 +36,6 @@ else:
         import six.moves.urllib.error as urllib_error
         URLLIB = True
         SECURE_DOWNLOAD = False
-
-from .errors import MediaTypeError
 
 
 IANA_URL = "https://www.iana.org/assignments/media-types/media-types.xml"
@@ -493,7 +488,7 @@ def _get_inherited_attribute(attribute, root, type_, method, is_):
 
 # TODO: refactor - this ain't pretty
 def _remove_duplicates(inherit_params, resource_params):
-    ret = []
+    ret = NodeList()
     if isinstance(resource_params[0], Body):
         _params = [p.mime_type for p in resource_params]
     else:

--- a/ramlfications/validate.py
+++ b/ramlfications/validate.py
@@ -8,7 +8,6 @@ import re
 from six import iterkeys
 
 from ._decorators import collecterrors
-
 from .errors import *  # NOQA
 
 

--- a/tests/test_nodelist.py
+++ b/tests/test_nodelist.py
@@ -1,0 +1,71 @@
+import pytest
+from ramlfications.nodelist import NodeList
+from ramlfications import errors
+
+
+class Person(object):
+    def __init__(self, first_name, last_name):
+        self.first_name = first_name
+        self.last_name = last_name
+
+
+class DictionaryPerson(dict):
+    pass
+
+
+def test_nodelist():
+    musk = Person(first_name='Elon', last_name='Musk')
+    torvalds = Person(first_name='Linus', last_name='Torvalds')
+    svensson = Person(first_name='Linus', last_name='Svensson')
+    persons = NodeList([musk, torvalds, svensson])
+    linuses = persons.filter_by(first_name='Linus')
+
+    assert persons.first() is musk
+    assert len(linuses) == 2
+    assert linuses.filter_by(last_name='Svensson').one() == svensson
+    assert linuses.first() == torvalds
+    assert (
+        linuses.filter_by(first_name='Linus').filter_by(last_name='Torvalds')
+        .one() ==
+        linuses.filter_by(first_name='Linus', last_name='Torvalds').one()
+    )
+
+    with pytest.raises(errors.InvalidNodeListFilterKey):
+        persons.filter_by(middle_name='1337')
+
+    with pytest.raises(errors.MultipleNodesFound):
+        linuses.one()
+
+    with pytest.raises(errors.NoNodeFound):
+        linuses.filter_by(first_name='Guido').one()
+
+    assert linuses.filter_by(first_name='Guido').first() is None
+
+
+def test_nodelist_dicts():
+    musk = DictionaryPerson(first_name='Elon', last_name='Musk')
+    torvalds = DictionaryPerson(first_name='Linus', last_name='Torvalds')
+    svensson = DictionaryPerson(first_name='Linus', last_name='Svensson')
+    persons = NodeList([musk, torvalds, svensson])
+    linuses = persons.filter_by(first_name='Linus')
+
+    assert persons.first() is musk
+    assert len(linuses) == 2
+    assert linuses.filter_by(last_name='Svensson').one() == svensson
+    assert linuses.first() == torvalds
+    assert (
+        linuses.filter_by(first_name='Linus').filter_by(last_name='Torvalds')
+        .one() ==
+        linuses.filter_by(first_name='Linus', last_name='Torvalds').one()
+    )
+
+    with pytest.raises(errors.InvalidNodeListFilterKey):
+        persons.filter_by(middle_name='1337')
+
+    with pytest.raises(errors.MultipleNodesFound):
+        linuses.one()
+
+    with pytest.raises(errors.NoNodeFound):
+        linuses.filter_by(first_name='Guido').one()
+
+    assert linuses.filter_by(first_name='Guido').first() is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2015 Spotify AB
-import sys
-
-if sys.version_info[0] == 2:
-    from io import open
-
 import json
 import os
 import tempfile
@@ -14,6 +9,7 @@ import pytest
 import xmltodict
 
 from ramlfications import utils
+from ramlfications._compat import open
 
 from .base import UPDATE
 


### PR DESCRIPTION
Allows for basic attribute filtering using `filter_by` method. The user-facing API is inspired by the SQLAlchemy Query object. Usage looks like this:

```python
root.resources = create_resources(root.raml_obj, NodeList(), root,
                                  parent=None)
post_resources = root.resources.filter_by(method='post')
image_resource = post_resources.filter_by(name='/image/').one()
```

The only place I'm using it in the existing codebase is in the call to `create_resources` in `ramlfications.parser.parse_raml`. But if you like the idea I'll gladly put it in other places it fits (which is basically any place where a list is used).