### PR TITLE
Fixed how args are passed to pytest in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ class PyTest(TestCommand):
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
-        self.pytest_args = None
+        self.pytest_args = ''
 
     def finalize_options(self):
         TestCommand.finalize_options(self)
@@ -69,7 +69,7 @@ class PyTest(TestCommand):
 
     def run_tests(self):
         import pytest
-        errno = pytest.main(self.pytest_args or [] + ["tests"])
+        errno = pytest.main(self.pytest_args + ' tests')
         sys.exit(errno)
 
 setup(


### PR DESCRIPTION
Following the instructions in the README for developer setup, if you create the env inside the project dir, when running tests with tox (or python setup.py test), the tests from all the dependencies are run too because pytest is discovering tests in the base dir.
This is because `self.pytest_args or [] + ["tests"]` is not doing what is expected (I guess?). self.pytest_args is a non-empty string (when running through tox), and OTOH, the + has higher precedence than the or.