### PR TITLE
Raise descriptive LoadRAMLError when invalid JSON data is loaded

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -140,7 +140,7 @@ To visualize a tree output of a RAML file:
 
 .. code-block:: bash
 
-   $ ramlfications tree /path/to/my-api.raml [-c|--color light/dark] [-v|vv|vvv] [-o|--output]
+   $ ramlfications tree /path/to/my-api.raml [--color light/dark] [-v|vv|vvv] [-o|--output]
 
 The least verbose option would show something like this:
 

--- a/ramlfications/loader.py
+++ b/ramlfications/loader.py
@@ -50,9 +50,14 @@ class RAMLLoader(object):
             base_path = base_path + "/"
         base_path = "file://" + base_path
 
-        with open(jsonfile, "r") as f:
-            schema = jsonref.load(f, base_uri=base_path, jsonschema=True)
-        return schema
+        try:
+            with open(jsonfile, "r") as f:
+                schema = jsonref.load(f, base_uri=base_path, jsonschema=True)
+        except ValueError as err:
+            msg = "ERROR: failed to parse JSON file: {0} ({1})"
+            raise LoadRAMLError(msg.format(jsonfile, err))
+        else:
+            return schema
 
     def _ordered_load(self, stream, loader=yaml.SafeLoader):
         """


### PR DESCRIPTION
- Without this try except clause you get two pages of not so descriptive
  stack traces.