### PR TITLE
Fix for issue 37: preserve URI order

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -63,12 +63,14 @@ raml
     .. py:attribute:: base_uri_params
 
         ``list`` of base :py:class:`.URIParameter` s for the base URI, or
-        ``None``.
+        ``None``. The order of ``base_uri_params`` will follow the order \
+        defined in the :py:obj:`.RootNode.base_uri`.
 
     .. py:attribute:: uri_params
 
         ``list`` of :py:class:`.URIParameter` s that can apply to all
-        resources, or ``None``.
+        resources, or ``None``. The order of ``uri_params`` will follow the \
+        order defined in the :py:obj:`.RootNode.base_uri`.
 
     .. py:attribute:: protocols
 
@@ -145,11 +147,15 @@ raml
 
     .. py:attribute:: uri_params
 
-        ``list`` of ``Node``’s :py:class:`.URIParameter` objects, or ``None``
+        ``list`` of ``Node``’s :py:class:`.URIParameter` objects, or ``None``. \
+        The order of ``uri_params`` will follow the order defined in the \
+        :py:obj:`.ResourceNode.absolute_uri`.
 
     .. py:attribute:: base_uri_params
 
-        ``list`` of ``Node``’s base :py:class:`.URIParameter` objects, or ``None``
+        ``list`` of ``Node``’s base :py:class:`.URIParameter` objects, or ``None``. \
+        The order of ``base_uri_params`` will follow the order defined in the \
+        :py:obj:`.ResourceNode.absolute_uri`.
 
     .. py:attribute:: query_params
 

--- a/docs/extendedusage.rst
+++ b/docs/extendedusage.rst
@@ -583,6 +583,11 @@ would be ``/foo/bar/{id}``, and the absolute URI path would be
    >>> foo_bar.parent
    <Resource(method='GET', path='/foo/bar/')>
 
+.. note::
+
+  The ``uri_params`` and ``base_uri_params`` on the ``api`` object (``RootNode``) and a resource object (``ResourceNode``) will **always** preserve order according to the absolute URI.
+
+
 Check out :doc:`api` for full definition of what is available for a ``resource`` object, and its associated attributes and objects.
 
 

--- a/ramlfications/__init__.py
+++ b/ramlfications/__init__.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import, division, print_function
 
 __author__ = "Lynn Root"
-__version__ = "0.1.8.dev0"
+__version__ = "0.1.9.dev0"
 __license__ = "Apache 2.0"
 
 __email__ = "lynn@spotify.com"

--- a/ramlfications/raml.py
+++ b/ramlfications/raml.py
@@ -28,9 +28,12 @@ class RootNode(object):
     :param dict raw: dict of loaded RAML data
     :param str version: API version
     :param str base_uri: API's base URI
-    :param list base_uri_params: parameters for base URI, or ``None``
+    :param list base_uri_params: parameters for base URI, or ``None``. \
+        The order of ``base_uri_params`` will follow the order \
+        defined in the :py:obj:`.RootNode.base_uri`.
     :param list uri_params: URI parameters that can apply to all resources, \
-        or ``None``
+        or ``None``. The order of ``uri_params`` will follow the order \
+        defined in the :py:obj:`.RootNode.base_uri`.
     :param list protocols: API-supported protocols, defaults to protocol \
         in ``base_uri``
     :param str title: API Title
@@ -83,11 +86,15 @@ class BaseNode(object):
     :param list responses: List of node's :py:class:`parameters.Response`\
         objects, or ``None``
     :param list uri_params: List of node's :py:class:`parameters.URIParameter`\
-        objects, or ``None``
+        objects, or ``None``. The order of ``uri_params`` will follow the \
+        order defined in the \
+        :py:obj:`.ResourceNode.absolute_uri`.
     :param list base_uri_params: List of node's base \
-        :py:obj:`parameters.URIParameter` objects, or ``None``
+        :py:obj:`parameters.URIParameter` objects, or ``None``. The order of \
+        ``base_uri_params`` will follow the order defined in the \
+        :py:attribute:`.ResourceNode.absolute_uri`.
     :param list query_params: List of node's \
-        :py:class:`parameters.QueryParameter` objects, or ``None``
+        :py:obj:`parameters.QueryParameter` objects, or ``None``
     :param list form_params: List of node's \
         :py:class:`parameters.FormParameter` objects, or ``None``
     :param str media_type: Supported request MIME media type. Defaults to \

--- a/ramlfications/utils.py
+++ b/ramlfications/utils.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function
 import json
 import logging
 import os
+import re
 import sys
 
 try:
@@ -678,3 +679,18 @@ def set_params(data, param_str, root, method, inherit=False, **kw):
 
     return __remove_duplicates(to_clean)
 # <--[query, base uri, form]-->
+
+
+# preserve order of URI and Base URI parameters
+# used for RootNode, ResourceNode
+def _preserve_uri_order(path, param_objs):
+    if not param_objs:
+        return param_objs
+    sorted_params = []
+    pattern = "\{(.*?)\}"
+    params = re.findall(pattern, path)
+    for p in params:
+        _param = [i for i in param_objs if i.name == p]
+        if _param:
+            sorted_params.append(_param[0])
+    return sorted_params

--- a/tests/data/examples/preserve-uri-order.raml
+++ b/tests/data/examples/preserve-uri-order.raml
@@ -1,0 +1,33 @@
+#%RAML 0.8
+title: Example API - Preserve URI Param order
+version: v1
+protocols: [ HTTPS ]
+baseUri: https://{subHostName}.{bucketName}.example.com/{version}/{lang}
+baseUriParameters:
+  subHostName:
+    description: The name of the sub domain host
+  bucketName:
+    description: The name of the bucket
+uriParameters:
+  lang:
+    description: Language desired
+mediaType: application/json
+/users/{user_id}/playlists:
+  uriParameters:
+    user_id:
+      displayName: User ID
+      type: string
+      description: The user's Spotify user ID.
+      example: smedjan
+  displayName: playlists
+  get:
+    description: Get a List of a User's Playlists
+  /{playlist_id}:
+    get:
+      description: Get a Playlist's Details
+      uriParameters:
+        playlist_id:
+          displayName: Playlist Id
+          type: string
+          description: ID of playlist
+          example: 123456

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -664,7 +664,15 @@ def test_resource_assigned_type(resources):
     assert res.method == "get"
     assert res.type == "item"
 
-    assert res.uri_params[0] == res.resource_type.uri_params[0]
+    res_type_uri = [r.name for r in res.resource_type.uri_params]
+    res_uri = [r.name for r in res.uri_params]
+
+    exp_res_type_uri = ["mediaTypeExtension"]
+    exp_res_uri = ["communityPath", "user_id", "thingy_id"]
+
+    assert res_type_uri == exp_res_type_uri
+    assert res_uri == exp_res_uri
+
     assert res.headers[0] == res.resource_type.headers[0]
     assert res.body[0] == res.resource_type.body[0]
     assert res.responses[0] == res.resource_type.responses[0]
@@ -1109,6 +1117,27 @@ def test_overwrite_protocol(resource_protocol):
     assert first.protocols == ["HTTP"]
     assert second.display_name == "track"
     assert second.protocols == ["HTTP"]
+
+
+@pytest.fixture(scope="session")
+def uri_param_resources():
+    raml_file = os.path.join(EXAMPLES, "preserve-uri-order.raml")
+    loaded_raml = load_file(raml_file)
+    config = setup_config(EXAMPLES + "test-config.ini")
+    config['validate'] = False
+    return pw.parse_raml(loaded_raml, config)
+
+
+def test_uri_params_order(uri_param_resources):
+    res = uri_param_resources.resources[1]
+    expected_uri = ["lang", "user_id", "playlist_id"]
+    expected_base = ["subHostName", "bucketName"]
+
+    uri = [u.name for u in res.uri_params]
+    base = [b.name for b in res.base_uri_params]
+
+    assert uri == expected_uri
+    assert base == expected_base
 
 
 #####


### PR DESCRIPTION
`base_uri_params` and `uri_params` now follow the `base_uri` order for the API Root, and `absolute_uri` for the individual resource endpoints.