### PR TITLE
Raml parser: support parsing fragments as the root node

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -42,7 +42,7 @@ parser
 raml
 ^^^^
 
-.. py:class:: ramlfications.raml.RootNode
+.. py:class:: ramlfications.raml.RootNodeAPI08
 
     API Root Node
 
@@ -62,18 +62,18 @@ raml
 
         ``list`` of base :py:class:`.URIParameter` s for the base URI, or
         ``None``. The order of ``base_uri_params`` will follow the order \
-        defined in the :py:obj:`.RootNode.base_uri`.
+        defined in the :py:obj:`.RootNodeAPI08.base_uri`.
 
     .. py:attribute:: uri_params
 
         ``list`` of :py:class:`.URIParameter` s that can apply to all
         resources, or ``None``. The order of ``uri_params`` will follow the \
-        order defined in the :py:obj:`.RootNode.base_uri`.
+        order defined in the :py:obj:`.RootNodeAPI08.base_uri`.
 
     .. py:attribute:: protocols
 
         ``list`` of ``str`` s of API-supported protocols.  If not defined, is
-        inferred by protocol from :py:obj:`.RootNode.base_uri`.
+        inferred by protocol from :py:obj:`.RootNodeAPI08.base_uri`.
 
     .. py:attribute:: title
 
@@ -129,7 +129,7 @@ raml
 
     .. py:attribute:: root
 
-        Back reference to the ``Node``’s API :py:class:`.RootNode` object.
+        Back reference to the ``Node``’s API :py:class:`.RootNodeAPI08` object.
 
     .. py:attribute:: headers
 
@@ -166,7 +166,7 @@ raml
     .. py:attribute:: media_type
 
         ``str`` of supported request MIME media type. Defaults to \
-        :py:class:`.RootNode`’s ``media_type``.
+        :py:class:`.RootNodeAPI08`’s ``media_type``.
 
     .. py:attribute:: description
 
@@ -175,7 +175,7 @@ raml
     .. py:attribute:: protocols
 
         ``list`` of ``str`` s of supported protocols.  Defaults to \
-        :py:obj:`.RootNode.protocols`.
+        :py:obj:`.RootNodeAPI08.protocols`.
 
 
 .. py:class:: ramlfications.raml.TraitNode
@@ -266,7 +266,7 @@ raml
     .. py:attribute:: absolute_uri
 
         ``str`` concatenation of absolute URI of resource:
-        :py:obj:`.RootNode.base_uri` + :py:attr:`path`.
+        :py:obj:`.RootNodeAPI08.base_uri` + :py:attr:`path`.
 
     .. py:attribute:: is_
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -26,7 +26,7 @@ RAML Versions
 
 | **Config variable**: ``raml_versions``
 | **Config type**: list of strings
-| **Supported**: ``0.8``
+| **Supported**: ``0.8``, ``1.0``
 |
 
 

--- a/docs/extendedusage.rst
+++ b/docs/extendedusage.rst
@@ -53,6 +53,8 @@ The Basics
    >>>
    >>> api.version
    v2
+   >>> api.raml_version
+   "0.8"
    >>> api.base_uri
    'https://{domainName}.foo.com/v2'
    >>> api.base_uri_parameters
@@ -87,7 +89,7 @@ With ``ramlfications``, documentation content and descriptions can either be vie
    u'<p>Welcome to the <em>Foo API</em> specification. For more information about\nhow to use the API, check out <a href="https://developer.foo.com">developer site</a>.</p>\n'
 
 
-Check out :doc:`api` for full definition of ``RootNode`` and its associated attributes and objects.
+Check out :doc:`api` for full definition of ``RootNodeAPI08`` and its associated attributes and objects.
 
 
 Security Schemes
@@ -585,7 +587,7 @@ would be ``/foo/bar/{id}``, and the absolute URI path would be
 
 .. note::
 
-  The ``uri_params`` and ``base_uri_params`` on the ``api`` object (``RootNode``) and a resource object (``ResourceNode``) will **always** preserve order according to the absolute URI.
+  The ``uri_params`` and ``base_uri_params`` on the ``api`` object (``RootNodeAPI08``) and a resource object (``ResourceNode``) will **always** preserve order according to the absolute URI.
 
 
 Check out :doc:`api` for full definition of what is available for a ``resource`` object, and its associated attributes and objects.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -15,7 +15,7 @@ To parse a RAML file, include ramlfications in your project and call the parse f
    >>> RAML_FILE = "/path/to/my-api.raml"
    >>> api = ramlfications.parse(RAML_FILE)
    >>> api
-   RootNode(title='Example Web API')
+   RootNodeAPI08(title='Example Web API')
    >>> api.title
    'My Foo API'
    >>> api.version

--- a/ramlfications/parser/__init__.py
+++ b/ramlfications/parser/__init__.py
@@ -13,6 +13,7 @@ from .main import (
     create_root, create_sec_schemes, create_traits, create_resource_types,
     create_resources
 )
+from .types import create_root_data_type
 
 __all__ = ["parse_raml"]
 
@@ -22,7 +23,7 @@ def parse_raml(loaded_raml, config):
     Parse loaded RAML file into RAML/Python objects.
 
     :param RAMLDict loaded_raml: OrderedDict of loaded RAML file
-    :returns: :py:class:`.raml.RootNode` object.
+    :returns: :py:class:`.raml.RootNodeAPI08` object.
     :raises: :py:class:`.errors.InvalidRAMLError` when RAML file is invalid
     """
     validate = str(_get(config, "validate")).lower() == 'true'
@@ -36,17 +37,22 @@ def parse_raml(loaded_raml, config):
             "RAML version not allowed in config {0}: allowed: {1}".format(
                 loaded_raml._raml_version, ", ".join(raml_versions)
             ))
-    root = create_root(loaded_raml, config)
-    attr.set_run_validators(validate)
 
-    root.security_schemes = create_sec_schemes(root.raml_obj, root)
-    root.traits = create_traits(root.raml_obj, root)
-    root.resource_types = create_resource_types(root.raml_obj, root)
-    root.resources = create_resources(root.raml_obj, [], root, parent=None)
+    if loaded_raml._raml_fragment_type == 'Root':
+        root = create_root(loaded_raml, config)
+        attr.set_run_validators(validate)
 
-    if validate:
-        attr.validate(root)  # need to validate again for root node
+        root.security_schemes = create_sec_schemes(root.raml_obj, root)
+        root.traits = create_traits(root.raml_obj, root)
+        root.resource_types = create_resource_types(root.raml_obj, root)
+        root.resources = create_resources(root.raml_obj, [], root, parent=None)
 
-        if root.errors:
-            raise InvalidRAMLError(root.errors)
-    return root
+        if validate:
+            attr.validate(root)  # need to validate again for root node
+
+            if root.errors:
+                raise InvalidRAMLError(root.errors)
+        return root
+
+    if loaded_raml._raml_fragment_type == 'DataType':
+        return create_root_data_type(loaded_raml)

--- a/ramlfications/parser/main.py
+++ b/ramlfications/parser/main.py
@@ -13,7 +13,7 @@ from ramlfications.parameters import (
     Documentation, SecurityScheme
 )
 from ramlfications.raml import (
-    RootNode, ResourceTypeNode, TraitNode, ResourceNode
+    RootNodeAPI08, ResourceTypeNode, TraitNode, ResourceNode
 )
 from ramlfications.utils import load_schema
 
@@ -28,10 +28,11 @@ from .parameters import create_param_objs
 
 def create_root(raml, config):
     """
-    Creates a :py:class:`.raml.RootNode` based off of the RAML's root section.
+    Creates a :py:class:`.raml.RootNodeAPI08` based off of the RAML's root
+    section.
 
     :param RAMLDict raml: loaded RAML file
-    :returns: :py:class:`.raml.RootNode` object with API root attributes set
+    :returns: :py:class:`.raml.RootNodeAPI08` object with API root attributes.
     """
 
     errors = []
@@ -81,9 +82,10 @@ def create_root(raml, config):
                   conf=config)
     base = base_uri_params(kwargs)
 
-    return RootNode(
+    return RootNodeAPI08(
         raml_obj=raml,
         raw=raml,
+        raml_version=raml._raml_version,
         title=_get(raml, "title"),
         version=_get(raml, "version"),
         protocols=protocols(),
@@ -104,7 +106,7 @@ def create_sec_schemes(raml_data, root):
     Parse security schemes into :py:class:.raml.SecurityScheme` objects
 
     :param dict raml_data: Raw RAML data
-    :param RootNode root: Root Node
+    :param RootNodeAPI08 root: Root Node
     :returns: list of :py:class:`.parameters.SecurityScheme` objects
     """
     schemes = _get(raml_data, "securitySchemes", [])
@@ -124,7 +126,7 @@ def _create_sec_scheme_node(name, data, root):
     :param str name: Name of the security scheme
     :param dict data: Raw method-level RAML data associated with \
         security scheme
-    :param RootNode root: API ``RootNode`` that the security scheme is \
+    :param RootNodeAPI08 root: API ``RootNodeAPI08`` that the security scheme \
         attached to
     :returns: :py:class:`.raml.SecurityScheme` object
     """
@@ -220,7 +222,7 @@ def create_traits(raml_data, root):
     Parse traits into :py:class:`.raml.TraitNode` objects.
 
     :param dict raml_data: Raw RAML data
-    :param RootNode root: Root Node
+    :param RootNodeAPI08 root: Root Node
     :returns: list of :py:class:`.raml.TraitNode` objects
     """
     traits = _get(raml_data, "traits", [])
@@ -241,7 +243,7 @@ def _create_trait_node(name, data, root):
     :param dict data: Raw method-level RAML data associated with \
         trait node
     :param str method: HTTP method associated with resource type node
-    :param RootNode root: API ``RootNode`` that the trait node is \
+    :param RootNodeAPI08 root: API ``RootNodeAPI08`` that the trait node is \
         attached to
     :returns: :py:class:`.raml.TraitNode` object
     """
@@ -265,7 +267,7 @@ def create_resource_types(raml_data, root):
     Parse resourceTypes into :py:class:`.raml.ResourceTypeNode` objects.
 
     :param dict raml_data: Raw RAML data
-    :param RootNode root: Root Node
+    :param RootNodeAPI08 root: Root Node
     :returns: list of :py:class:`.raml.ResourceTypeNode` objects
     """
     accepted_methods = _get(root.config, "http_optional")
@@ -309,8 +311,8 @@ def _create_resource_type_node(name, method_data, method, resource_data, root):
     :param str method: HTTP method associated with resource type node
     :param dict resource_data: Raw resource-level RAML data associated with \
         resource type node
-    :param RootNode root: API ``RootNode`` that the resource type node is \
-        attached to
+    :param RootNodeAPI08 root: API ``RootNodeAPI08`` that the resource type\
+        node is attached to
     :returns: :py:class:`.raml.ResourceTypeNode` object
     """
     #####
@@ -355,7 +357,7 @@ def create_resources(node, resources, root, parent):
 
     :param dict node: Dictionary of node to traverse
     :param list resources: List of collected ``.raml.ResourceNode`` s
-    :param RootNode root: The ``.raml.RootNode`` of the API
+    :param RootNodeAPI08 root: The ``.raml.RootNodeAPI08`` of the API
     :param ResourceNode parent: Parent ``.raml.ResourceNode`` of current \
         ``node``
     :returns: List of :py:class:`.raml.ResourceNode` objects.
@@ -386,7 +388,8 @@ def _create_resource_node(name, raw_data, method, parent, root):
     :param dict raw_data: Raw RAML data associated with resource node
     :param str method: HTTP method associated with resource node
     :param ResourceNode parent: Parent node object of resource node, if any
-    :param RootNode api: API ``RootNode`` that the resource node is attached to
+    :param RootNodeAPI08 api: API ``RootNodeAPI08`` that the resource node\
+        is attached to
     :returns: :py:class:`.raml.ResourceNode` object
     """
     #####
@@ -477,7 +480,8 @@ def _create_base_node(name, root, node_type, kwargs, resolve_from=[]):
     Create a dictionary of :py:class:`.raml.BaseNode` data.
 
     :param str name: Name of resource node
-    :param RootNode api: API ``RootNode`` that the resource node is attached to
+    :param RootNodeAPI08 api: API ``RootNodeAPI08`` that the resource node is\
+        attached to
     :param str node_type: type of node, e.g. ``resource``, ``resource_type``
     :param dict kwargs: relevant node data to parse out
     :param list resolve_from: order of objects from which the node to \

--- a/ramlfications/parser/types.py
+++ b/ramlfications/parser/types.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015 The Ramlfications developers
+
+from ramlfications.raml import RootNodeDataType
+
+
+def create_root_data_type(raml):
+    """
+    Creates a :py:class:`.raml.RootNodeDataType` based off of the RAML's root\
+        section.
+
+    :param RAMLDict raml: loaded RAML file
+    :returns: :py:class:`.raml.RootNodeDataType` object with API root\
+        attributes set
+    """
+
+    return RootNodeDataType(
+        raml_obj=raml,
+        raw=raml
+    )

--- a/ramlfications/raml.py
+++ b/ramlfications/raml.py
@@ -24,19 +24,32 @@ RESOURCE_PROPERTIES = METHOD_PROPERTIES + ["base_uri_params", "uri_params"]
 
 
 @attr.s
-class RootNode(object):
+class RootNodeBase(object):
     """
     API Root Node
 
+    This is the base node for api raml, or fragments
+
     :param dict raw: dict of loaded RAML data
+    :param str raml_version: RAML spec version
+    """
+    raw              = attr.ib(repr=False)
+    raml_version     = attr.ib(repr=False)
+
+
+@attr.s
+class RootNodeAPIBase(RootNodeBase):
+    """
+    API Root Node base for API files
+
     :param str version: API version
     :param str base_uri: API's base URI
     :param list base_uri_params: parameters for base URI, or ``None``. \
         The order of ``base_uri_params`` will follow the order \
-        defined in the :py:obj:`.RootNode.base_uri`.
+        defined in the :py:obj:`.RootNodeAPI08.base_uri`.
     :param list uri_params: URI parameters that can apply to all resources, \
         or ``None``. The order of ``uri_params`` will follow the order \
-        defined in the :py:obj:`.RootNode.base_uri`.
+        defined in the :py:obj:`.RootNodeAPI08.base_uri`.
     :param list protocols: API-supported protocols, defaults to protocol \
         in ``base_uri``
     :param str title: API Title
@@ -54,7 +67,6 @@ class RootNode(object):
         or ``None``
     :param raml_obj: loaded :py:class:`raml.RAMLDict` object
     """
-    raw              = attr.ib(repr=False)
     version          = attr.ib(repr=False, validator=root_version)
     base_uri         = attr.ib(repr=False, validator=root_base_uri)
     base_uri_params  = attr.ib(repr=False,
@@ -78,10 +90,31 @@ class RootNode(object):
 
 
 @attr.s
+class RootNodeAPI08(RootNodeAPIBase):
+    """
+    API Root Node for 0.8 raml files
+    """
+
+
+@attr.s
+class RootNodeAPI10(RootNodeAPIBase):
+    """
+    API Root Node for 1.0 raml files
+    """
+    types            = attr.ib(repr=False)
+
+
+@attr.s
+class RootNodeDataType(RootNodeBase):
+    """
+    API Root Node for 1.0 DataType fragment files
+    """
+
+
+@attr.s
 class BaseNode(object):
     """
-    :param dict raw: The raw data parsed from the RAML file
-    :param RootNode root: Back reference to the node's API root
+    :param RootNodeAPI08 root: Back reference to the node's API root
     :param list headers: List of node's :py:class:`parameters.Header` \
         objects, or ``None``
     :param list body: List of node's :py:class:`parameters.Body` objects, \
@@ -101,10 +134,10 @@ class BaseNode(object):
     :param list form_params: List of node's \
         :py:class:`parameters.FormParameter` objects, or ``None``
     :param str media_type: Supported request MIME media type. Defaults to \
-        :py:class:`RootNode`'s ``media_type``.
+        :py:class:`RootNodeAPI08`'s ``media_type``.
     :param str description: Description of node.
     :param list protocols: List of ``str`` 's of supported protocols. \
-        Defaults to :py:class:`RootNode`'s ``protocols``.
+        Defaults to :py:class:`RootNodeAPI08`'s ``protocols``.
     """
     root            = attr.ib(repr=False)
     headers         = attr.ib(repr=False)
@@ -188,7 +221,7 @@ class ResourceNode(BaseNode):
         defaults to ``name``
     :param str path: relative path of resource
     :param str absolute_uri: Absolute URI of resource: \
-        :py:class:`RootNode`'s ``base_uri`` + ``path``
+        :py:class:`RootNodeAPI08`'s ``base_uri`` + ``path``
     :param list is\_: A list of ``str`` s or ``dict`` s of resource-assigned \
         traits, or ``None``
     :param list traits: A list of assigned :py:class:`TraitNode` objects, \

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -10,7 +10,7 @@ import pytest
 from ramlfications import parse
 from ramlfications import parser as pw
 from ramlfications.config import setup_config
-from ramlfications.raml import RootNode, ResourceTypeNode, TraitNode
+from ramlfications.raml import RootNodeAPI08, ResourceTypeNode, TraitNode
 from ramlfications.utils import load_file
 
 from tests.base import EXAMPLES
@@ -26,7 +26,7 @@ def test_parse_raml(github_raml):
     config_file = os.path.join(EXAMPLES, "github-config.ini")
     config = setup_config(config_file)
     root = pw.parse_raml(github_raml, config)
-    assert isinstance(root, RootNode)
+    assert isinstance(root, RootNodeAPI08)
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_twitter.py
+++ b/tests/integration/test_twitter.py
@@ -10,7 +10,7 @@ import pytest
 from ramlfications import parser as pw
 from ramlfications.config import setup_config
 from ramlfications.raml import (
-    RootNode, ResourceTypeNode, TraitNode, ResourceNode
+    RootNodeAPI08, ResourceTypeNode, TraitNode, ResourceNode
 )
 from ramlfications.utils import load_file
 
@@ -27,7 +27,7 @@ def test_parse_raml(raml):
     config_file = os.path.join(EXAMPLES, "twitter-config.ini")
     config = setup_config(config_file)
     root = pw.parse_raml(raml, config)
-    assert isinstance(root, RootNode)
+    assert isinstance(root, RootNodeAPI08)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 from ramlfications import parse, load, loads, validate
-from ramlfications.raml import RootNode
+from ramlfications.raml import RootNodeAPI08
 from ramlfications.errors import LoadRAMLError
 
 from .base import EXAMPLES
@@ -31,7 +31,7 @@ def test_parse(raml):
     config = os.path.join(EXAMPLES + "test-config.ini")
     result = parse(raml, config)
     assert result
-    assert isinstance(result, RootNode)
+    assert isinstance(result, RootNodeAPI08)
 
 
 def test_parse_nonexistant_file():

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -285,3 +285,26 @@ def test_parse_noversion():
         loader.RAMLLoader().load(f)
     msg = "Error raml file shall start with #%RAML"
     assert msg in e.value.args[0]
+
+
+def test_parse_ramlfragment():
+    f = StringIO("#%RAML 1.0 DataType")
+    raml = loader.RAMLLoader().load(f)
+    assert raml._raml_version == "1.0"
+    assert raml._raml_fragment_type == "DataType"
+
+
+def test_parse_ramlfragment08():
+    f = StringIO("#%RAML 0.8 DataType")
+    with pytest.raises(LoadRAMLError) as e:
+        loader.RAMLLoader().load(f)
+    msg = "Error raml fragment is only possible with version 1.0"
+    assert msg in e.value.args[0]
+
+
+def test_parse_ramlfragment_unknown_type():
+    f = StringIO("#%RAML 0.8 garbage")
+    with pytest.raises(LoadRAMLError) as e:
+        loader.RAMLLoader().load(f)
+    msg = "Error raml fragment is only possible with version 1.0"
+    assert msg in e.value.args[0]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,7 +9,7 @@ import pytest
 
 from ramlfications import parser as pw
 from ramlfications.config import setup_config
-from ramlfications.raml import RootNode, ResourceTypeNode, TraitNode
+from ramlfications.raml import RootNodeAPI08, ResourceTypeNode, TraitNode
 from ramlfications.utils import load_file
 
 from .base import EXAMPLES
@@ -32,11 +32,11 @@ def root():
 def test_parse_raml(loaded_raml):
     config = setup_config(EXAMPLES + "test-config.ini")
     root = pw.parse_raml(loaded_raml, config)
-    assert isinstance(root, RootNode)
+    assert isinstance(root, RootNodeAPI08)
 
 
 def test_create_root(root):
-    assert isinstance(root, RootNode)
+    assert isinstance(root, RootNodeAPI08)
 
 
 def test_base_uri(root):


### PR DESCRIPTION
Trying to spilt my big PR into smaller PR in the hope I can get something merged
Actually, this led to a much bigger PR, but dont worry, it is mostly a find replace renaming of RootNode...


For now, only datatype is introduced (actual implementation will be in the data type PR)

raml1.0 introduces possibility to split your REST api def into several parts

Interresting side effect of this is that you can use raml as a data-validator library.

a raml datatype file can be used for the same means as:
json schema
http://cerberus.readthedocs.org
https://pypi.python.org/pypi/yamltypes