### PR TITLE
Fix the assert_called_once() problem, and avert PYTHONHASHSEED hardcoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_script:
   - pip install tox codecov
 
 script:
-- tox --hashseed 0
+- tox
 
 after_success:
 - codecov

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,6 +6,7 @@ contributors:
 
 - `Hynek Schlawack <https://github.com/hynek>`_
 - `Matt Montag <https://github.com/mmontag>`_
+- `Piët Delport <https://github.com/pjdelport>`_
 
 
 .. _`Lynn Root`: https://github.com/econchick

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -676,10 +676,11 @@ def test_resource_assigned_type(resources):
     assert res.headers[0] == res.resource_type.headers[0]
     assert res.body[0] == res.resource_type.body[0]
     assert res.responses[0] == res.resource_type.responses[0]
-    assert len(res.headers) == 3
-    assert res.headers[0].name == "X-another-header"
-    assert res.headers[1].name == "Accept"
-    assert res.headers[2].name == "X-example-header"
+    assert set([h.name for h in res.headers]) == set([
+        "X-another-header",
+        "Accept",
+        "X-example-header",
+    ])
 
     res = resources[18]
     assert res.type == "collection"
@@ -961,10 +962,13 @@ def test_resource_inherits_type_optional_get(inherited_resources):
 
 def test_resource_inherits_get(inherited_resources):
     assert len(inherited_resources.resources) == 7
-    post_res = inherited_resources.resources[3]
-    get_res = inherited_resources.resources[4]
 
-    assert get_res.method == "get"
+    rs = [r for r in inherited_resources.resources
+          if r.path == '/another-post-resource']
+    assert len(rs) == 2
+    [post_res] = [r for r in rs if r.method == 'post']
+    [get_res] = [r for r in rs if r.method == 'get']
+
     assert len(get_res.headers) == 1
     assert len(get_res.body) == 1
     assert len(get_res.responses) == 2
@@ -990,7 +994,6 @@ def test_resource_inherits_get(inherited_resources):
     assert q.max_length == 50
     assert q.required is True
 
-    assert post_res.method == "post"
     assert post_res.description.raw == "post some more foobar"
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = py26, py27, py33, py34, py35, pypy, flake8, manifest, docs
 
 [testenv]
 setenv =
-    PYTHONHASHSEED = 0
     LC_ALL=en_US.utf-8
     LANG=en_US.utf-8
 deps = -rtox-requirements.txt
@@ -13,7 +12,6 @@ commands =
 [testenv:py26]
 basepython = python2.6
 setenv =
-    PYTHONHASHSEED = 0
     LC_ALL=en_US.utf-8
     LANG=en_US.utf-8
 deps = -rtox-requirements.txt
@@ -25,7 +23,6 @@ commands =
 [testenv:pypy]
 basepython = pypy
 setenv =
-    PYTHONHASHSEED = 0
     LC_ALL=en_US.utf-8
     LANG=en_US.utf-8
 deps = -rtox-requirements.txt
@@ -58,7 +55,6 @@ commands =
 [testenv:docs]
 basepython = python2.7
 setenv =
-    PYTHONHASHSEED = 0
     LC_ALL=en_US.utf-8
     LANG=en_US.utf-8
 deps =


### PR DESCRIPTION
This fixes the `assert_called_once()` false positives (see PR #86, and [this article](http://engineeringblog.yelp.com/2015/02/assert_called_once-threat-or-menace.html)), and makes the tests pass on Python 3.5 (which adds a new check for that problem).

This also improves some assertions to be independent of Python's hashing order, so that the tests now pass deterministically without `PYTHONHASHSEED = 0`.