### PR TITLE
Corrected processing of reserved parameter <<resourcePathName>>

### DIFF
--- a/ramlfications/utils/parser.py
+++ b/ramlfications/utils/parser.py
@@ -45,7 +45,7 @@ def resolve_inherited_scalar(item, inherit_from=[], **kwargs):
     path = _get(kwargs, "resource_path")
     path_name = "<<resourcePathName>>"
     if path:
-        path_name = path.lstrip("/")
+        path_name = path.split("/")[-1]
     else:
         path = "<<resourcePath>>"
     for obj_type in inherit_from:

--- a/tests/data/examples/resourcePathName_multilevel_resource.raml
+++ b/tests/data/examples/resourcePathName_multilevel_resource.raml
@@ -1,0 +1,10 @@
+#%RAML 0.8
+title: resourcePathName for multilevel resources test
+version: v1
+baseUri: http://localhost:8080
+/internal:
+  description: <<resourcePathName>>
+  /secondLevel:
+    description: <<resourcePathName>>
+    /thirdLevel:
+      description: <<resourcePathName>>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1777,3 +1777,17 @@ doner andouille cupim meatball. Porchetta hamburger filet mignon jerky flank, \
 meatball salami beef cow venison tail ball tip pork belly.</p>
 """
     assert api.documentation[0].content.html == markdown_html
+
+
+@pytest.fixture(scope="session")
+def multilevel_api():
+    raml_file = os.path.join(
+        EXAMPLES + "resourcePathName_multilevel_resource.raml")
+    loaded_raml_file = load_file(raml_file)
+    config = setup_config(EXAMPLES + "test-config.ini")
+    return pw.parse_raml(loaded_raml_file, config)
+
+
+def test_resourcePathName_with_multilevel_resource(multilevel_api):
+    for resource in multilevel_api.resources:
+        assert resource.desc == resource.path.split("/")[-1]


### PR DESCRIPTION
The [parameters](https://github.com/raml-org/raml-spec/blob/master/raml-0.8.md#parameters) section of the RAML 0.8 spec states that the ``<<resourcePathName>>`` reserved parameter should be populated with the section of the resource path after the right-most '/' character. Currently ``ramlfications`` populates the ``<<resourcePathName>>`` parameter with the section of the resource path after the _left-most_ '/' character. This change corrects this behaviour.