### PR TITLE
Fix for repeated application of parameter transforms to parameter values

### DIFF
--- a/ramlfications/utils/common.py
+++ b/ramlfications/utils/common.py
@@ -134,13 +134,15 @@ def __replace_str_attr(param, new_value, current_str):
     for item in ret:
         to_replace = "".join(item[0:3]) + item[-1]
         tag_func = item[3]
+        transformed_value = new_value
         if tag_func:
             tag_func = tag_func.strip("!")
             tag_func = tag_func.strip()
             func = getattr(tags, tag_func)
             if func:
-                new_value = func(new_value)
-        current_str = current_str.replace(to_replace, str(new_value), 1)
+                transformed_value = func(new_value)
+        current_str = current_str.replace(
+            to_replace, str(transformed_value), 1)
     return current_str
 
 

--- a/tests/data/examples/repeated-parameter-transformation.raml
+++ b/tests/data/examples/repeated-parameter-transformation.raml
@@ -1,0 +1,11 @@
+#%RAML 0.8
+title: Parameterised Resource Test
+version: v1
+baseUri: http://localhost:8080
+resourceTypes:
+  - collection:
+      get:
+        description: <<resourcePathName|!singularize>> <<resourcePathName|!singularize>>
+/jobs:
+  /jobs:
+    type: collection

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1846,3 +1846,21 @@ def test_extended_external_resource_with_multiple_methods(
     # Make sure the change didn't break existing functionality
     for method in "get", "patch", "post":
         assert method in internal_resource_methods
+
+
+@pytest.fixture(scope="session")
+def repeated_parameter_transformation():
+    raml_file = os.path.join(
+        EXAMPLES + "repeated-parameter-transformation.raml")
+    loaded_raml_file = load_file(raml_file)
+    config = setup_config(EXAMPLES + "test-config.ini")
+    return pw.parse_raml(loaded_raml_file, config)
+
+
+def test_repeated_parameter_transformation(
+        repeated_parameter_transformation):
+    api = repeated_parameter_transformation
+    assert len(api.resources) == 2
+    get_resources = [r for r in api.resources if r.method == "get"]
+    for r in get_resources:
+        assert r.desc == "job job"


### PR DESCRIPTION
When a transformed parameter appears more than once in a single field in a RAML file, the transform is applied each time the transformed parameter appears. This can cause problems with the singularize transform: for example, singularizing 'users' once results in 'user', and then singularizing 'user' results in the non-string value False. This patch fixes this problem by not overwriting the original parameter value with the result of the transformation.