### PR TITLE
ramlfications.models.data_types: add missing import

### DIFF
--- a/ramlfications/models/data_types.py
+++ b/ramlfications/models/data_types.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, print_function
 
 import copy
+import re
 
 import attr
 from six import iteritems


### PR DESCRIPTION
Added a missing import.

Tests that should exercise this code are currently disabled; re-enabling **tests/raml10tests/test_types.py** ``test_string_with_validation`` is going to take a bit more time understanding how ramlfications works under the hood than I've time for today, but this allowed me to at least parse the RAML I've got for my project now.