### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,9 +119,9 @@ Feel free to drop by ``#ramlfications`` on Freenode (`webchat`_) or ping via `Tw
 .. _pyenv: https://github.com/yyuu/pyenv
 .. _Sphinx: http://sphinx-doc.org/
 .. _`Read the Docs`: https://github.com/snide/sphinx_rtd_theme
-.. _`Read the Docs site`: https://ramlfications.readthedocs.org
-.. _`usage`: http://ramlfications.readthedocs.org/en/latest/usage.html
-.. _`How to Contribute`: http://ramlfications.readthedocs.org/en/latest/contributing.html
+.. _`Read the Docs site`: https://ramlfications.readthedocs.io
+.. _`usage`: https://ramlfications.readthedocs.io/en/latest/usage.html
+.. _`How to Contribute`: https://ramlfications.readthedocs.io/en/latest/contributing.html
 .. _`webchat`: http://webchat.freenode.net?channels=%23ramlfications&uio=ND10cnVlJjk9dHJ1ZQb4
 .. _`econchick`: https://github.com/econchick
 .. _`Twitter`: https://twitter.com/roguelynn

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -131,4 +131,4 @@ To use via the command line:
 .. _`default media type`: http://raml.org/spec.html#default-media-type
 .. _IANA: https://www.iana.org/assignments/media-types/media-types.xml
 .. _GitHub: https://github.com/spotify/ramlfications/blob/master/ramlfications/data/supported_mime_types.json
-.. _validate: https://ramlfications.readthedocs.org/en/latest/usage.html#validate
+.. _validate: https://ramlfications.readthedocs.io/en/latest/usage.html#validate

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -36,7 +36,7 @@ It’s tested on Python 2.6, 2.7, 3.3+, and PyPy. Both Linux and OS X are suppor
 
 
 .. _`Documentation Set`: http://raml.org/
-.. _`Read the Docs`: https://ramlfications.readthedocs.org/
+.. _`Read the Docs`: https://ramlfications.readthedocs.io/
 .. _`GitHub`:  https://github.com/spotify/ramlfications/
 .. _`pyraml-parser`: https://github.com/an2deg/pyraml-parser
 .. _`uriParameters`: https://github.com/an2deg/pyraml-parser/issues/6

--- a/ramlfications/__init__.py
+++ b/ramlfications/__init__.py
@@ -14,7 +14,7 @@ __version__ = "0.1.9"
 __license__ = "Apache 2.0"
 
 __email__ = "lynn@spotify.com"
-__uri__ = "https://ramlfications.readthedocs.org"
+__uri__ = "https://ramlfications.readthedocs.io"
 __description__ = "A Python RAML parser"
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.