### PR TITLE
Add raml org data testing

### DIFF
--- a/ramlfications/models/base.py
+++ b/ramlfications/models/base.py
@@ -160,12 +160,6 @@ class BaseParameterAttrs(object):
                      validator=attr.validators.instance_of(dict))
     errors = attr.ib(repr=False)
 
-    @property
-    def description(self):
-        if self.desc:
-            return BaseContent(self.desc)
-        return None
-
 
 @attr.s
 class BaseParameter(BaseNamedParameter, BaseParameterAttrs):
@@ -180,3 +174,9 @@ class BaseParameter(BaseNamedParameter, BaseParameterAttrs):
         ``ramlfications`` library.
     :param list errors: List of RAML validation errors.
     """
+
+    @property
+    def description(self):
+        if self.desc:
+            return BaseContent(self.desc)
+        return None

--- a/ramlfications/models/base.py
+++ b/ramlfications/models/base.py
@@ -28,14 +28,17 @@ class BaseContent(object):
         """
         Return raw Markdown/plain text written in the RAML file
         """
-        return self.data
+        if self.data:
+            return self.data
+        return ""
 
     @property
     def html(self):
         """
         Returns parsed Markdown into HTML
         """
-        return md.markdown(self.data)
+        if self.data:
+            return md.markdown(self.data)
 
     def __repr__(self):
         return self.raw

--- a/ramlfications/models/data_types.py
+++ b/ramlfications/models/data_types.py
@@ -136,7 +136,7 @@ class ObjectDataType(BaseDataType):
                                     convert=parse_properties)
     min_properties        = attr.ib(repr=False, default=0)
     max_properties        = attr.ib(repr=False, default=None)
-    additional_properties = attr.ib(repr=False, default=True)
+    additional_properties = attr.ib(repr=False, default=None)
     discriminator         = attr.ib(repr=False, default=None)
     # TODO: validate based on if discriminator is set in type declaration
     discriminator_value   = attr.ib(repr=False, default=None,

--- a/ramlfications/models/parameters.py
+++ b/ramlfications/models/parameters.py
@@ -114,7 +114,6 @@ class Response(BaseParameterAttrs):
     :param str method: HTTP request method associated with response.
     """
     code     = attr.ib(validator=response_code)
-    desc     = attr.ib(repr=False)
     headers  = attr.ib(repr=False)
     body     = attr.ib(repr=False)
     method   = attr.ib(default=None)

--- a/ramlfications/models/parameters.py
+++ b/ramlfications/models/parameters.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 
 import attr
 
-from .base import BaseParameter, BaseParameterAttrs
+from .base import BaseContent, BaseParameter, BaseParameterAttrs
 from ramlfications.validate import *  # NOQA
 
 
@@ -114,9 +114,17 @@ class Response(BaseParameterAttrs):
     :param str method: HTTP request method associated with response.
     """
     code     = attr.ib(validator=response_code)
+    desc     = attr.ib(repr=False)
     headers  = attr.ib(repr=False)
     body     = attr.ib(repr=False)
     method   = attr.ib(default=None)
+
+    # TODO: I'm not liking how I copy-pasted this here :-/
+    @property
+    def description(self):
+        if self.desc:
+            return BaseContent(self.desc)
+        return None
 
 
 # FIXME: this currently isn't used... probably will need to use it though

--- a/ramlfications/parser/parameters.py
+++ b/ramlfications/parser/parameters.py
@@ -55,7 +55,7 @@ class BaseParameterParser(object):
             )
             if param_obj is Header:
                 kwargs["method"] = _get(kw, "method")
-            if param_obj not in (Response, Body):
+            if param_obj is not Body:
                 kwargs["desc"] = _get(value, "description")
 
             item = param_obj(**kwargs)
@@ -253,6 +253,7 @@ class ResponseParser(BaseParameterParser, BodyParserMixin):
     def parse(self):
         headers = self.parse_response_headers()
         body = self.parse_response_body()
+        desc = _get(self.data, "description", None)
 
         if isinstance(self.code, string_types):
             try:
@@ -265,6 +266,7 @@ class ResponseParser(BaseParameterParser, BodyParserMixin):
             code=self.code,
             raw={self.code: self.data},
             method=self.method,
+            desc=desc,
             headers=headers,
             body=body,
             config=self.root.config,

--- a/ramlfications/parser/parameters.py
+++ b/ramlfications/parser/parameters.py
@@ -38,7 +38,6 @@ class BaseParameterParser(object):
                 name=key,
                 raw={key: value},
                 data_type=data_type,
-                desc=_get(value, "description"),
                 display_name=_get(value, "displayName", key),
                 min_length=_get(value, "minLength"),
                 max_length=_get(value, "maxLength"),
@@ -56,6 +55,8 @@ class BaseParameterParser(object):
             )
             if param_obj is Header:
                 kwargs["method"] = _get(kw, "method")
+            if param_obj not in (Response, Body):
+                kwargs["desc"] = _get(value, "description")
 
             item = param_obj(**kwargs)
             objects.append(item)
@@ -252,7 +253,6 @@ class ResponseParser(BaseParameterParser, BodyParserMixin):
     def parse(self):
         headers = self.parse_response_headers()
         body = self.parse_response_body()
-        desc = _get(self.data, "description", None)
 
         if isinstance(self.code, string_types):
             try:
@@ -265,7 +265,6 @@ class ResponseParser(BaseParameterParser, BodyParserMixin):
             code=self.code,
             raw={self.code: self.data},
             method=self.method,
-            desc=desc,
             headers=headers,
             body=body,
             config=self.root.config,

--- a/ramlfications/validate/root.py
+++ b/ramlfications/validate/root.py
@@ -88,10 +88,10 @@ def root_docs(inst, attr, value):
     """
     if value:
         for d in value:
-            if d.title.raw is None:
+            if not d.title.raw:
                 msg = "API Documentation requires a title."
                 raise InvalidRootNodeError(msg)
-            if d.content.raw is None:
+            if not d.content.raw:
                 msg = "API Documentation requires content defined."
                 raise InvalidRootNodeError(msg)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -17,6 +17,15 @@ JSONREF = os.path.join(PAR_DIR + '/data/jsonref/')
 RAML_ORG_EXAMPLES = os.path.join(DATA_DIR, 'ramlorgexamples')
 
 
+DATA_TYPE_OBJECT_ATTRS = [
+    'additional_properties', 'annotation', 'config', 'default',
+    'description', 'discriminator', 'discriminator_value',
+    'display_name', 'errors', 'example', 'examples', 'facets',
+    'max_properties', 'min_properties', 'name', 'properties',
+    'raml_version', 'raw', 'root', 'schema', 'type', 'usage', 'xml'
+]
+
+
 class AssertNotSetError(Exception):
     pass
 

--- a/tests/data/ramlorgexamples/typesystem/complex.raml
+++ b/tests/data/ramlorgexamples/typesystem/complex.raml
@@ -1,0 +1,60 @@
+#%RAML 1.0
+title: My API with Types
+mediaType: application/json
+types:
+  Org:
+    type: object
+    properties:
+      onCall: Alertable # inherits all properties from type `Alertable`
+      Head: Manager # inherits all properties from type `Manager`
+  Person:
+    type: object
+    discriminator: kind # reference to the `kind` property of `Person`
+    properties:
+      firstname: string
+      lastname: string
+      title?: string
+      kind: string # may be used to differenciate between classes that extend from `Person`
+  Phone:
+    type: string
+    pattern: "^[0-9|-]+$" # defines pattern for the content of type `Phone`
+  Manager:
+    type: Person # inherits all properties from type `Person`
+    properties:
+      reports: Person[] # inherits all properties from type `Person`; array type where `[]` is a shortcut
+      phone:  Phone
+  Admin:
+    type: Person # inherits all properties from type `Person`
+    properties:
+      clearanceLevel:
+        enum: [ low, high ]
+  AlertableAdmin:
+    type: Admin # inherits all properties from type `Admin`
+    properties:
+      phone: Phone # inherits all properties from type `Phone`; uses shortcut syntax
+  Alertable:
+    type: Manager #| AlertableAdmin # union type; either a `Manager` or `AlertableAdmin`
+/orgs/{orgId}:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            type: Org # reference to global type definition
+            example:
+              onCall:
+                firstname: nico
+                lastname: ark
+                kind: admin
+                clearanceLevel: low
+                phone: "12321"
+              Head:
+                firstname: nico
+                lastname: ark
+                kind: manager
+                reports:
+                  -
+                    firstname: nico
+                    lastname: ark
+                    kind: admin
+                phone: "123-23"

--- a/tests/integration/raml_examples/typesystem/test_complex.py
+++ b/tests/integration/raml_examples/typesystem/test_complex.py
@@ -1,0 +1,414 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2016 Spotify AB
+from __future__ import absolute_import, division, print_function
+
+import os
+
+import pytest
+
+from ramlfications.config import setup_config
+from ramlfications.models import data_types
+from ramlfications.parser import parse_raml
+from ramlfications.utils import load_file
+
+from tests.base import (
+    DATA_TYPE_OBJECT_ATTRS, RAML_ORG_EXAMPLES, assert_not_set
+)
+
+
+def _test_attrs_set(item, attrs_to_exp):
+    for attrib, exp in attrs_to_exp:
+        assert getattr(item, attrib) == exp
+
+
+@pytest.fixture(scope="session")
+def api():
+    typesystem = os.path.join(RAML_ORG_EXAMPLES, "typesystem")
+    ramlfile = os.path.join(typesystem, "complex.raml")
+    loaded_raml = load_file(ramlfile)
+    configfile = os.path.join(RAML_ORG_EXAMPLES, "simple_config.ini")
+    config = setup_config(configfile)
+    return parse_raml(loaded_raml, config)
+
+
+def test_root(api):
+    assert api.title == "My API with Types"
+    assert api.media_type == "application/json"
+    assert len(api.types) == 7
+    assert len(api.resources) == 1
+    assert not api.resource_types
+    assert not api.traits
+    assert not api.security_schemes
+
+
+def test_org_type(api):
+    org = api.types[0]
+    attrs_to_exp = [
+        ("name", "Org"),
+        ("type", "object"),
+        ("display_name", "Org"),
+        ("raml_version", "1.0")
+    ]
+    _test_attrs_set(org, attrs_to_exp)
+    assert len(org.properties) == 2
+    assert sorted(org.properties.keys()) == sorted(["onCall", "Head"])
+    assert isinstance(org, data_types.ObjectDataType)
+
+    on_call = org.properties.get("onCall")
+    assert on_call.type == "Alertable"
+    assert not on_call.required
+    assert not on_call.default
+    # TODO: add support
+    # assert on_call.data_type.name == "Alertable"
+
+    not_set = [
+        'additional_properties', 'annotation', 'default', 'discriminator',
+        'discriminator_value', 'errors', 'example', 'examples', 'facets',
+        'max_properties', 'min_properties', 'schema', 'usage', 'xml'
+    ]
+    assert_not_set(org, not_set)
+    assert not org.description.html
+    assert not org.description.raw
+
+
+def test_person_type(api):
+    person = api.types[1]
+
+    attrs_to_exp = [
+        ("name", "Person"),
+        ("display_name", "Person"),
+        ("type", "object"),
+        ("discriminator", "kind"),
+        ("raml_version", "1.0")
+    ]
+    _test_attrs_set(person, attrs_to_exp)
+    assert isinstance(person, data_types.ObjectDataType)
+
+    not_set = [
+        'additional_properties', 'annotation', 'default',
+        'discriminator_value', 'errors', 'example', 'examples', 'facets',
+        'max_properties', 'min_properties', 'schema', 'usage', 'xml'
+    ]
+    assert_not_set(person, not_set)
+
+    assert len(person.properties) == 4
+    not_set = ["default", "required"]
+    for v in person.properties.values():
+        assert_not_set(v, not_set)
+        _test_attrs_set(v, [("type", "string")])
+
+
+def test_phone_type(api):
+    phone = api.types[2]
+    attrs_to_exp = [
+        ("name", "Phone"),
+        ("display_name", "Phone"),
+        ("type", "string"),
+        ("max_length", 2147483647),
+        ("raml_version", "1.0")
+    ]
+    _test_attrs_set(phone, attrs_to_exp)
+    assert not phone.description.raw
+    assert not phone.description.html
+    assert phone.pattern.pattern == "^[0-9|-]+$"
+    assert isinstance(phone, data_types.StringDataType)
+
+    not_set = [
+        'annotation', 'default', 'enum', 'errors', 'example',
+        'examples', 'facets', 'min_length', 'schema', 'usage', 'xml'
+    ]
+    assert_not_set(phone, not_set)
+
+
+def test_manager_type(api):
+    manager = api.types[3]
+    attrs_to_exp = [
+        ("name", "Manager"),
+        ("display_name", "Manager"),
+        ("type", "Person"),
+        ("raml_version", "1.0"),
+        ("discriminator", "kind")
+    ]
+    _test_attrs_set(manager, attrs_to_exp)
+    assert isinstance(manager, data_types.ObjectDataType)
+
+    not_set = [
+        'additional_properties', 'annotation', 'default',
+        'discriminator_value', 'errors', 'example', 'examples', 'facets',
+        'max_properties', 'min_properties', 'schema', 'usage', 'xml'
+    ]
+    assert_not_set(manager, not_set)
+    _set = ["config", "raw", "root"]
+    for s in _set:
+        assert getattr(manager, s)
+
+    props = manager.properties
+    assert len(props) == 6
+    first = props.get("firstname")
+    last = props.get("lastname")
+    title = props.get("title?")
+    kind = props.get("kind")
+    reports = props.get("reports")
+    phone = props.get("phone")
+
+    not_set = ["required", "default"]
+    for v in props.values():
+        assert_not_set(v, not_set)
+
+    assert first.type == "string"
+    assert last.type == "string"
+    assert title.type == "string"
+    assert kind.type == "string"
+    assert reports.type == "Person[]"
+    assert phone.type == "Phone"
+
+
+def test_admin_type(api):
+    admin = api.types[4]
+    attrs_to_exp = [
+        ("name", "Admin"),
+        ("display_name", "Admin"),
+        ("type", "Person"),
+        ("discriminator", "kind"),
+        ("raml_version", "1.0")
+    ]
+    _test_attrs_set(admin, attrs_to_exp)
+
+    assert isinstance(admin, data_types.ObjectDataType)
+
+    not_set = [
+        'additional_properties', 'annotation', 'default',
+        'discriminator_value', 'errors', 'example', 'examples', 'facets',
+        'max_properties', 'min_properties', 'schema', 'usage', 'xml'
+    ]
+    assert_not_set(admin, not_set)
+    _set = ["config", "raw", "root"]
+    for s in _set:
+        assert getattr(admin, s)
+
+    assert len(admin.properties) == 5
+    not_set = ["required", "default"]
+    for v in admin.properties.values():
+        assert_not_set(v, not_set)
+
+    first = admin.properties.get("firstname")
+    last = admin.properties.get("lastname")
+    title = admin.properties.get("title?")
+    kind = admin.properties.get("kind")
+    clearance = admin.properties.get("clearanceLevel")
+    assert first.type == "string"
+    assert last.type == "string"
+    assert title.type == "string"
+    assert kind.type == "string"
+    # TODO: fixme - this should be an enum type
+    assert clearance.type == "string"
+
+
+def test_alertable_admin_type(api):
+    alert_admin = api.types[5]
+    attrs_to_exp = [
+        ("name", "AlertableAdmin"),
+        ("display_name", "AlertableAdmin"),
+        ("type", "Admin"),
+        ("discriminator", "kind"),
+        ("raml_version", "1.0")
+    ]
+    _test_attrs_set(alert_admin, attrs_to_exp)
+
+    assert isinstance(alert_admin, data_types.ObjectDataType)
+
+    not_set = [
+        'additional_properties', 'annotation', 'default',
+        'discriminator_value', 'errors', 'example', 'examples', 'facets',
+        'max_properties', 'min_properties', 'schema', 'usage', 'xml'
+    ]
+    assert_not_set(alert_admin, not_set)
+    _set = ["config", "raw", "root"]
+    for s in _set:
+        assert getattr(alert_admin, s)
+
+    assert len(alert_admin.properties) == 6
+    not_set = ["required", "default"]
+    for v in alert_admin.properties.values():
+        assert_not_set(v, not_set)
+
+    first = alert_admin.properties.get("firstname")
+    last = alert_admin.properties.get("lastname")
+    title = alert_admin.properties.get("title?")
+    kind = alert_admin.properties.get("kind")
+    clearance = alert_admin.properties.get("clearanceLevel")
+    phone = alert_admin.properties.get("phone")
+
+    assert first.type == "string"
+    assert last.type == "string"
+    assert title.type == "string"
+    assert kind.type == "string"
+    # TODO: fixme - this should be an enum type
+    assert clearance.type == "string"
+    assert phone.type == "Phone"
+
+
+# TODO: fixme when support for union types is added
+def test_alertable_type(api):
+    alertable = api.types[6]
+    attrs_to_exp = [
+        ("name", "Alertable"),
+        ("display_name", "Alertable"),
+        ("type", "Manager"),
+        ("discriminator", "kind"),
+        ("raml_version", "1.0")
+    ]
+    _test_attrs_set(alertable, attrs_to_exp)
+
+    assert isinstance(alertable, data_types.ObjectDataType)
+
+    not_set = [
+        'additional_properties', 'annotation', 'default',
+        'discriminator_value', 'errors', 'example', 'examples', 'facets',
+        'max_properties', 'min_properties', 'schema', 'usage', 'xml'
+    ]
+    assert_not_set(alertable, not_set)
+    _set = ["config", "raw", "root"]
+    for s in _set:
+        assert getattr(alertable, s)
+
+    assert len(alertable.properties) == 6
+    not_set = ["required", "default"]
+    for v in alertable.properties.values():
+        assert_not_set(v, not_set)
+
+    first = alertable.properties.get("firstname")
+    last = alertable.properties.get("lastname")
+    title = alertable.properties.get("title?")
+    kind = alertable.properties.get("kind")
+    reports = alertable.properties.get("reports")
+    phone = alertable.properties.get("phone")
+    assert first.type == "string"
+    assert last.type == "string"
+    assert title.type == "string"
+    assert kind.type == "string"
+    # TODO: fixme - this should be an enum type
+    assert reports.type == "Person[]"
+    assert phone.type == "Phone"
+
+
+def test_resource(api):
+    res = api.resources[0]
+    attrs_to_exp = [
+        ("name", "/orgs/{orgId}"),
+        ("display_name", "/orgs/{orgId}"),
+        ("method", "get"),
+        # why is this a list?!
+        ("absolute_uri", ["/orgs/{orgId}"]),
+        ("media_type", "application/json"),
+        ("path", "/orgs/{orgId}"),
+        # TODO: fixme - this should just be none or something
+        ("protocols", [""])
+    ]
+    _test_attrs_set(res, attrs_to_exp)
+
+    not_set = [
+        'base_uri_params', 'body', 'desc', 'errors', 'form_params',
+        'headers', 'is_', 'parent', 'query_params', 'resource_type',
+        'secured_by', 'security_schemes', 'traits', 'type'
+    ]
+    assert_not_set(res, not_set)
+
+    _set = ["raw", "root", "description"]
+    for s in _set:
+        assert getattr(res, s)
+
+    assert len(res.uri_params) == 1
+    u_param = res.uri_params[0]
+
+    attrs_to_exp = [
+        ("name", "orgId"),
+        ("display_name", "orgId"),
+        ("type", "string"),
+        ("required", True)
+    ]
+    _test_attrs_set(u_param, attrs_to_exp)
+
+    not_set = [
+        'data_type', 'default', 'desc', 'description',
+        'enum', 'errors', 'example', 'max_length',
+        'maximum', 'min_length', 'minimum', 'pattern',
+        'repeat',
+    ]
+    assert_not_set(u_param, not_set)
+    _set = ["config", "raw"]
+    for s in _set:
+        assert getattr(u_param, s)
+
+    assert len(res.responses) == 1
+    resp = res.responses[0]
+
+    attrs_to_exp = [
+        ("code", 200),
+        ("method", "get")
+    ]
+    _test_attrs_set(resp, attrs_to_exp)
+
+    not_set = [
+        'errors', 'headers'
+    ]
+    assert_not_set(resp, not_set)
+    _set = ["config", "raw"]
+    for s in _set:
+        assert getattr(resp, s)
+
+    assert len(resp.body) == 1
+    body = resp.body[0]
+
+    attrs_to_exp = [
+        ("mime_type", "application/json"),
+        ("type", "Org"),
+    ]
+    _test_attrs_set(body, attrs_to_exp)
+
+    not_set = [
+        'errors', 'form_params', 'schema'
+    ]
+    assert_not_set(body, not_set)
+    _set = ["config", "raw"]
+    for s in _set:
+        assert getattr(body, s)
+
+    _set = [
+        "config", "raw", "description", "root", "properties",
+        "name", "display_name", "type", "raml_version"
+    ]
+    for s in _set:
+        assert getattr(body.data_type, s)
+
+    attrs_to_exp = [
+        ("name", "Org"),
+        ("display_name", "Org"),
+        ("type", "object"),
+        ("raml_version", "1.0")
+    ]
+    _test_attrs_set(body.data_type, attrs_to_exp)
+    not_set = set(DATA_TYPE_OBJECT_ATTRS) - set(_set)
+    assert_not_set(body.data_type, not_set)
+
+    # TODO: once example object implementation is done, update this test
+    expected_example = {
+        'onCall': {
+            'firstname': 'nico',
+            'lastname': 'ark',
+            'kind': 'admin',
+            'clearanceLevel': 'low',
+            'phone': '12321'
+        },
+        'Head': {
+            'firstname': 'nico',
+            'lastname': 'ark',
+            'kind': 'manager',
+            'reports': [{
+                'firstname': 'nico',
+                'lastname': 'ark',
+                'kind': 'admin'}],
+            'phone': '123-23'
+        }
+    }
+    assert body.example == expected_example

--- a/tox.ini
+++ b/tox.ini
@@ -10,17 +10,6 @@ deps = -rtox-requirements.txt
 commands =
     python setup.py test -a "-v --cov ramlfications --cov-report xml"
 
-; TODO: Remove me, just for development
-[testenv:dev]
-basepython = python2.7
-setenv =
-    PYTHONHASHSEED = 0
-    LC_ALL=en_US.utf-8
-    LANG=en_US.utf-8
-deps = -rtox-requirements.txt
-commands =
-    py.test tests/v020tests/
-
 [testenv:py26]
 basepython = python2.6
 setenv =


### PR DESCRIPTION
Added some integration tests for examples in [raml.org's repo](https://github.com/raml-org/raml-examples). There is still a lot of features needed for data types, but this starts to lay the ground for more complete integration testing based off of "official" examples.