### PR TITLE
Fix parse string

### DIFF
--- a/ramlfications/__init__.py
+++ b/ramlfications/__init__.py
@@ -65,7 +65,12 @@ def parse(raml, config_file=None):
     :raises InvalidParameterError: Named parameter is invalid \
         according to RAML `specification <http://raml.org/spec.html>`_.
     """
-    loader = load(raml)
+    if "#%RAML" in raml:
+        # This has RAML declaration so it's not a filepath
+        # Load from string
+        loader = loads(raml)
+    else:
+        loader = load(raml)
     config = setup_config(config_file)
     return parse_raml(loader, config)
 

--- a/ramlfications/config.py
+++ b/ramlfications/config.py
@@ -19,6 +19,7 @@ def _load_media_types():
     with open(media_types_file, "r") as f:
         return json.load(f)
 
+
 HTTP_METHODS = [
     "get", "post", "put", "delete", "patch", "head",
     "options", "trace", "connect"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -33,11 +33,13 @@ def test_parse_filepath(raml):
     assert result
     assert isinstance(result, RootNode)
 
+
 def test_parse_string(raml_string):
     config = os.path.join(EXAMPLES + "test-config.ini")
     result = parse(raml_string, config)
     assert result
     assert isinstance(result, RootNode)
+
 
 def test_parse_nonexistant_file():
     raml_file = "/tmp/non-existant-raml-file.raml"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -27,12 +27,17 @@ baseUri: https://api.github.com/
 """
 
 
-def test_parse(raml):
+def test_parse_filepath(raml):
     config = os.path.join(EXAMPLES + "test-config.ini")
     result = parse(raml, config)
     assert result
     assert isinstance(result, RootNode)
 
+def test_parse_string(raml_string):
+    config = os.path.join(EXAMPLES + "test-config.ini")
+    result = parse(raml_string, config)
+    assert result
+    assert isinstance(result, RootNode)
 
 def test_parse_nonexistant_file():
     raml_file = "/tmp/non-existant-raml-file.raml"


### PR DESCRIPTION
Documentation for ramlfications.parse() says that it allows either a file path to a raml doc or a raml doc as a string.  This is incorrect, it only allows a file path and does not check to see if a complete raml doc as a string has been passed.  This PR fixes that behavior and allows either a filepath or whole raml doc to be passed to parse()