### PR TITLE
upgrade markdown dependency due to CVE-2018-5773

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==3.11
-markdown2 => 2.3.5
+markdown2=>2.3.5
 click==3.3
 termcolor==1.1.0
 six==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==3.11
-markdown2 ~> 2.3.5
+markdown2 => 2.3.5
 click==3.3
 termcolor==1.1.0
 six==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==3.11
-markdown2==2.3.0
+markdown2 ~> 2.3.5
 click==3.3
 termcolor==1.1.0
 six==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==3.11
-markdown2=>2.3.5
+markdown2==2.3.6
 click==3.3
 termcolor==1.1.0
 six==1.8.0


### PR DESCRIPTION
this was an automated suggestion made by Github's dependency tool